### PR TITLE
✨ [Feat] IsFirstShoot이냐에 따라서 분기 처리 - 내보내기 버튼, 다음 버튼 연결

### DIFF
--- a/Chalkak/App/ChalkakApp.swift
+++ b/Chalkak/App/ChalkakApp.swift
@@ -12,7 +12,7 @@ import SwiftUI
 struct ChalkakApp: App {
     var body: some Scene {
         WindowGroup {
-            ClipEditView(clipURL: Bundle.main.url(forResource: "sample-video", withExtension: "mov")!, isFirstShoot: true)
+            CameraView()
         }
         .modelContainer(for: [Project.self, Clip.self, Guide.self])
     }

--- a/Chalkak/Presentation/ClipEdit/ClipEditView.swift
+++ b/Chalkak/Presentation/ClipEdit/ClipEditView.swift
@@ -17,6 +17,8 @@ struct ClipEditView: View {
     
     @State private var isDragging = false
     private var isFirstShoot: Bool = true
+    
+    @State private var navigateToCameraView = false
         
     init(clipURL: URL, isFirstShoot: Bool) {
         _editViewModel = StateObject(wrappedValue: ClipEditViewModel(context: nil, clipURL: clipURL))
@@ -61,18 +63,34 @@ struct ClipEditView: View {
                         print("뒤로가기 버튼 눌림")
                     }
                 }
+                
+                if !isFirstShoot {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button("내보내기") {
+                            // TODO: 내보내기 기능 구현
+                            print("내보내기 버튼 눌림")
+                        }
+                    }
+                }
 
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("다음") {
-                        overlayViewModel.prepareOverlay(
-                            from: editViewModel.clipURL,
-                            at: editViewModel.startPoint
-                        )
+                        if isFirstShoot {
+                            overlayViewModel.prepareOverlay(
+                                from: editViewModel.clipURL,
+                                at: editViewModel.startPoint
+                            )
+                        } else {
+                            navigateToCameraView = true
+                        }
                     }
                 }
             }
             .navigationDestination(isPresented: $overlayViewModel.isOverlayReady) {
                 OverlayView(overlayViewModel: overlayViewModel)
+            }
+            .navigationDestination(isPresented: $navigateToCameraView) {
+                //TODO: - 가이드 있는 카메라 뷰파인더로 연결(Berry)
             }
             .onAppear {
                 editViewModel.updateContext(modelContext)


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #22

## ✨ PR Content
> 작업 내용 설명을 적어주세요.
첫번째 슛이나 아니야에 따라 분기 처리
isFirstShoot
- true -> 내보내기 버튼 없음, 가이드 생성 화면으로 이동
- false -> 내보내기 버튼 있음, 가이드 카메라 뷰파인더 화면으로 이동

## 📸 Screenshot
> 작업 화면의 스크린샷을 추가해주세요.
<img width="1179" height="2556" alt="IMG_7420" src="https://github.com/user-attachments/assets/f6b21105-7983-42c1-9103-62662b872113" />


## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요

- 특이 사항 1. 뒤로가기 버튼 눌렀을 때 뷰파인더로 이동해야 하는데, 이부분은 그냥 핀의 CameraView() 호출하면 되는건지. 아니면 dismiss로 back 해야하는건지 궁금합니다.!
- 특이 사항 2 뒤로가기 버튼 눌렀을 때 만약 그게 첫번째 샷이면 카메라 화면으로 돌아가야 하고 / 
                    아니면 가이드 카메라 화면으로 돌아가야할텐데, 이부분은 분기 나눌 필요 없이 dismiss하면 알아서 처리 되나요.?
또 첫번째 샷이면 카메라 화면으로 돌아갔다 다시 클립편집할 때 isFirstShoot이 true여야 하고 /
두번째 샷부터는 가이드 카메라 화면으로 뒤로갔다가 다시 클립편집할 때 isFirstShoot이 false여야할텐데
이 부분도 그냥 dismiss로 pop하게 하면 저절로 해결되는건지 잘 모르겠어서,,, 그냥 dismiss 처리하면 되는건지 궁금합니다.!
 

## ✅ Checklist
- [ ] Merge 하는 브랜치가 올바른지 확인
- [ ] 필요없는 주석, 프린트문 제거했는지 확인
- [ ] PR과 관련없는 변경사항 없는지 확인
- [ ] 컨벤션 지켰는지 확인
