### PR TITLE
✨ [feat] #24 녹화 완료 시 클립 편집 뷰로 전환

### DIFF
--- a/Chalkak/App/ChalkakApp.swift
+++ b/Chalkak/App/ChalkakApp.swift
@@ -12,10 +12,8 @@ import SwiftUI
 struct ChalkakApp: App {
     var body: some Scene {
         WindowGroup {
-            ClipEditView(clipURL: Bundle.main.url(forResource: "sample-video", withExtension: "mov")!, isFirstShoot: true)
+            CameraView()
         }
         .modelContainer(for: [Project.self, Clip.self, Guide.self])
     }
 }
-
-


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #24 

## ✨ PR Content

CameraManager.swift
- 기존 촬영 종료시 `fileoutput`함수에서 사진 라이브러리에 저장하던 로직을 제거했습니다.
- 촬영 종료시 NotificationCenter를 통해 `VideoSaved` 알림을 전송하고, userInfo에 방금 촬영한 파일의 URL을 전달하게 했습니다. 


CameraView.swift
- `NavigationStack`추가 
- `VideoSaved` 알림 구독
- 알림을 받으면 함께 전달된 영상 URL을 사용하여 ClipEditView로 이동하도록 구현


## 📸 Screenshot
https://github.com/user-attachments/assets/99ffe957-03b1-40b9-b6cb-9b35750cdfa7

## 📍 PR Point 
```swift
.navigationDestination(isPresented: $navigateToEdit) {
                if let url = clipUrl {
                    ClipEditView(clipURL: url, isFirstShoot: true)
                }
            }
```
현재 임시로 `isFirstShoot`자체를 상수값 `true`로 설정을 해줬는데, sprint2에서는 곧 `userDefaults` 키값이 확정되면 그에따른 조건문을 넣어주겠습니다! 

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
