### PR TITLE
✨ [Feat] Project, Clip, Guide 데이터 관리 구현

### DIFF
--- a/Chalkak/Data/Model/Guide.swift
+++ b/Chalkak/Data/Model/Guide.swift
@@ -16,7 +16,7 @@ class Guide: Identifiable {
     @Attribute(.unique) var clipID: String
     
     /// 화면 내 바운딩 박스의 위치.
-    var bBoxPosition: CGPoint
+    var bBoxPosition: PointWrapper
     
     /// 카메라로부터의 거리 비교를 위한 바운딩 박스의 크기.
     var bBoxScale: CGFloat
@@ -49,7 +49,7 @@ class Guide: Identifiable {
     ///   - createdAt: 생성 시각 (기본값은 현재 시간).
     init(
         clipID: String,
-        bBoxPosition: CGPoint,
+        bBoxPosition: PointWrapper,
         bBoxScale: CGFloat,
         outlineImage: UIImage,
         cameraTilt: Tilt,
@@ -63,5 +63,19 @@ class Guide: Identifiable {
         self.cameraHeight = cameraHeight
         self.createdAt = createdAt
         self.outlineImageData = outlineImage.pngData() ?? Data()
+    }
+}
+
+struct PointWrapper: Codable {
+    var x: CGFloat
+    var y: CGFloat
+    
+    init(_ point: CGPoint) {
+        self.x = point.x
+        self.y = point.y
+    }
+    
+    var cgPoint: CGPoint {
+        CGPoint(x: x, y: y)
     }
 }

--- a/Chalkak/Data/SwiftDataManager.swift
+++ b/Chalkak/Data/SwiftDataManager.swift
@@ -69,8 +69,12 @@ class SwiftDataManager {
     // MARK: - Project
     
     /// `Project` 생성
-    func createProject(guide: Guide? = nil, clips: [Clip] = []) -> Project {
-        let newProject = Project(guide: guide, clipList: clips)
+    func createProject(
+        id: String,
+        guide: Guide? = nil,
+        clips: [Clip] = []
+    ) -> Project {
+        let newProject = Project(id: id, guide: guide, clipList: clips)
         context.insert(newProject)
         return newProject
     }
@@ -78,6 +82,13 @@ class SwiftDataManager {
     // TODO: - 프로젝트 단의 관리 시작 시점에 구현 (Berry)
     //    func fetchAllProjects() -> [Project] {
     //    }
+    
+    /// `Project` id 이용해 조회
+    func fetchProject(byID id: String) -> Project? {
+        let predicate = #Predicate<Project> { $0.id == id }
+        let descriptor = FetchDescriptor<Project>(predicate: predicate)
+        return try? context.fetch(descriptor).first
+    }
 
     /// `Project` 삭제
     func deleteProject(_ project: Project) {
@@ -88,6 +99,7 @@ class SwiftDataManager {
 
     /// `Clip` 생성
     func createClip(
+        id: String,
         videoURL: URL,
         startPoint: Double = 0,
         endPoint: Double,
@@ -95,6 +107,7 @@ class SwiftDataManager {
         heightList: [TimeStampedHeight] = []
     ) -> Clip {
         let clip = Clip(
+            id: id,
             videoURL: videoURL,
             startPoint: startPoint,
             endPoint: endPoint,
@@ -122,7 +135,7 @@ class SwiftDataManager {
     /// `Guide` 생성
     func createGuide(
         clipID: String,
-        bBoxPosition: CGPoint,
+        bBoxPosition: PointWrapper,
         bBoxScale: CGFloat,
         outlineImage: UIImage,
         cameraTilt: Tilt,

--- a/Chalkak/Presentation/ClipEdit/ClipEditView.swift
+++ b/Chalkak/Presentation/ClipEdit/ClipEditView.swift
@@ -68,24 +68,25 @@ struct ClipEditView: View {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("다음") {
                         if isFirstShoot {
+                            editViewModel.saveProjectData()
                             overlayViewModel.prepareOverlay(
                                 from: editViewModel.clipURL,
                                 at: editViewModel.startPoint
                             )
                         } else {
+                            editViewModel.appendClipToCurrentProject()
                             navigateToCameraView = true
                         }
                     }
                 }
             }
             .navigationDestination(isPresented: $overlayViewModel.isOverlayReady) {
-                OverlayView(overlayViewModel: overlayViewModel)
+                if let clipID = editViewModel.clipID {
+                    OverlayView(overlayViewModel: overlayViewModel, clipID: clipID)
+                }
             }
             .navigationDestination(isPresented: $navigateToCameraView) {
                 //TODO: - 가이드 있는 카메라 뷰파인더로 연결(Berry)
-            }
-            .onAppear {
-                editViewModel.updateContext(modelContext)
             }
     }
 }

--- a/Chalkak/Presentation/Guide/Overlay/OverlayView.swift
+++ b/Chalkak/Presentation/Guide/Overlay/OverlayView.swift
@@ -11,7 +11,10 @@ import SwiftUI
 struct OverlayView: View {
     @ObservedObject var overlayViewModel: OverlayViewModel
     @Environment(\.dismiss) private var dismiss
+    @State private var navigateToCameraView = false
 
+    let clipID: String
+    
     var body: some View {
         VStack(alignment: .center, spacing: 20, content: {
             
@@ -37,10 +40,8 @@ struct OverlayView: View {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button("다음") {
                     /// 가이드 객체 생성
-                    if let guide = overlayViewModel.makeGuide() {
-                        print("--- GUIDE ---")
-                        print(guide)/// 생성된 Guide 확인
-                        //TODO: - guide를 다음 화면으로 전달하거나 저장(Berry)
+                    if let guide = overlayViewModel.makeGuide(clipID: clipID) {
+                        navigateToCameraView = true
                     } else {
                         print("❌ guide 생성 실패")
                     }

--- a/Chalkak/Presentation/Guide/Overlay/OverlayViewModel.swift
+++ b/Chalkak/Presentation/Guide/Overlay/OverlayViewModel.swift
@@ -46,20 +46,23 @@ final class OverlayViewModel: ObservableObject {
     }
 
     /// Guide 객체 생성
-    func makeGuide() -> Guide? {
+    @MainActor
+    func makeGuide(clipID: String) -> Guide? {
         guard let outlineImage = overlayManager.outlineImage, let bBox = overlayManager.boundingBox else {
             print("❌ outlineImage가 없습니다.")
             return nil
         }
         
-        let guide = Guide(
-            clipID: "dummy-id",
-            bBoxPosition: bBox.origin,
+        let guide = SwiftDataManager.shared.createGuide(
+            clipID: clipID,
+            bBoxPosition: PointWrapper(bBox.origin),
             bBoxScale: bBox.width,
             outlineImage: outlineImage,
             cameraTilt: Tilt(degreeX: 0, degreeZ: 0),
             cameraHeight: 1.0
         )
+        
+        SwiftDataManager.shared.saveContext()
         
         return guide
     }


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #27
- Resolved: #28

## ✨ PR Content
> 작업 내용 설명을 적어주세요.

SwiftData에 저장하기 위한 데이터 타입 변경을 진행했습니다.
각각 Project, Clip, Guide의 저장 필요 시점에 맞는 로직을 구현하였습니다.


## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요

- Clip의 VideoURL
영상의 바이너리 데이터를 vidoeURL 네임으로 저장하고 있습니다.
아까 논의 과정에서 Project 안에서 하나로 연결되어 완성된 영상을 video 네이밍으로 가져가자는 얘기가 나왔어서
이 부분 수정하면 되는지 궁금합니다.
논의의 결과를 듣지 못해서요..!

- Guide bBoxPosition 타입
원래는 CGPoint 타입이었습니다. 바운딩박스의 위치 값 타입이 CGPoint이기 때문에요.
그런데 SwiftData에는 CGPoint를 저장할 수 없었고, Wrapper를 따로 만들어 CGFloat 값들의 형태로 저장할 수 있도록 만들었습니다.

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
