### PR TITLE
🐛 [fix] guidoutlineImage 인터렉션 방지 로직 추가

### DIFF
--- a/Chalkak/Presentation/Guide/Distance/BoundingBoxView.swift
+++ b/Chalkak/Presentation/Guide/Distance/BoundingBoxView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct BoundingBoxView: View {
     let guide: Guide?
     let isFirstShoot: Bool
-    
+
     @StateObject private var viewModel = BoundingBoxViewModel()
     @StateObject private var cameraViewModel = CameraViewModel()
 
@@ -24,28 +24,30 @@ struct BoundingBoxView: View {
                         .ignoresSafeArea()
                         .transition(.opacity)
                 }
-                
+
                 CameraView(isFirstShoot: isFirstShoot, guide: guide, viewModel: cameraViewModel)
                     .onAppear {
                         cameraViewModel.setBoundingBoxUpdateHandler { bboxes in
                             viewModel.liveBoundingBoxes = bboxes
                         }
                     }
-                
+
                 if let guide = guide, let outline = guide.outlineImage {
                     Image(uiImage: outline)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 296, height: 526)
+                        .allowsHitTesting(false)
                 } else {
                     Text("윤곽선 이미지 없음")
                         .foregroundColor(.gray)
+                        .allowsHitTesting(false)
                 }
-                
+
                 // TODO: - Height, Tilt 피드백 뷰 띄우기
             }
         }
-        .onAppear() {
+        .onAppear {
             if let guide = guide {
                 viewModel.setReference(from: guide)
             }


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #40 

## ✨ PR Content
`CameraView` 위에 `guide.outlineImage`가 오버레이되면서, 해당 이미지 영역의 터치 이벤트가 `CameraView`의 기능(ZoomSlider, touctAtPoint) 인터렉션의 버벅임을 주는 문제

#### BoundingBoxView.swift
- `guide.outlineImage`에 `.allowsHitTesting(false)` 속성 적용 
- 해당 이미지의 터치 이벤트를 비활성화하고 모든 인터랙션이 하위의 `CameraView`로 전달되도록 수정했습니다.

```swift
 if let guide = guide, let outline = guide.outlineImage {
                    Image(uiImage: outline)
                        .resizable()
                        .aspectRatio(contentMode: .fit)
                        .frame(width: 296, height: 526)
                        .allowsHitTesting(false)
                } else {
                    Text("윤곽선 이미지 없음")
                        .foregroundColor(.gray)
                        .allowsHitTesting(false)
}
```

## 📍 PR Point 
> 인터렉션 방지 로직 중에 더 나은 방식이 있다면 공유해주시면 감사드리겠습니다.

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인