### PR TITLE
🐛 [fix] 바운딩 박스 위치 및 실루엣 오버레이 크기 수정

### DIFF
--- a/Chalkak/Data/Model/Guide.swift
+++ b/Chalkak/Data/Model/Guide.swift
@@ -76,6 +76,6 @@ struct PointWrapper: Codable {
     }
     
     var cgPoint: CGPoint {
-        CGPoint(x: x, y: y)
+        CGPoint(x: x, y: y * 0.9)
     }
 }

--- a/Chalkak/Presentation/Guide/Distance/BoundingBoxView.swift
+++ b/Chalkak/Presentation/Guide/Distance/BoundingBoxView.swift
@@ -25,21 +25,22 @@ struct BoundingBoxView: View {
                         .transition(.opacity)
                 }
                 
-                CameraView(isFirstShoot: isFirstShoot, guide: guide, viewModel: cameraViewModel)
-                    .onAppear {
-                        cameraViewModel.setBoundingBoxUpdateHandler { bboxes in
-                            viewModel.liveBoundingBoxes = bboxes
+                ZStack {
+                    CameraView(isFirstShoot: isFirstShoot, guide: guide, viewModel: cameraViewModel)
+                        .onAppear {
+                            cameraViewModel.setBoundingBoxUpdateHandler { bboxes in
+                                viewModel.liveBoundingBoxes = bboxes
+                            }
                         }
+                    
+                    if let guide = guide, let outline = guide.outlineImage {
+                        Image(uiImage: outline)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                    } else {
+                        Text("윤곽선 이미지 없음")
+                            .foregroundColor(.gray)
                     }
-                
-                if let guide = guide, let outline = guide.outlineImage {
-                    Image(uiImage: outline)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 296, height: 526)
-                } else {
-                    Text("윤곽선 이미지 없음")
-                        .foregroundColor(.gray)
                 }
                 
                 // TODO: - Height, Tilt 피드백 뷰 띄우기


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #이슈번호

## ✨ PR Content
> 작업 내용 설명을 적어주세요.

바운딩 박스의 피드백의 기준이 되는 위치를 조정했습니다.
실루엣 오버레이를 가이드 카메라에 띄울때의 크기를 조정했습니다.


## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
