### PR TITLE
🐛 [Fix] #45 전면카메라 결과물에 대해 isVideoMirror 속성 적용

### DIFF
--- a/Chalkak/Core/CameraKit/CameraManager.swift
+++ b/Chalkak/Core/CameraKit/CameraManager.swift
@@ -162,6 +162,12 @@ class CameraManager: NSObject, ObservableObject {
                 print("카메라 전환 중 오류: \(error)")
             }
         }
+        
+        if let connection = movieOutput.connection(with: .video) {
+            if connection.isVideoMirroringSupported {
+                connection.isVideoMirrored = position == .front
+            }
+        }
 
         session.commitConfiguration()
     }


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #45  

## ✨ PR Content
미리보기와 최종 저장되는 영상 결과물이 동일하게 좌우 반전되어있도록 수정했습니다.
>`SwitchCamera` 메서드 내에서 카메라 위치가 전면(`.front`)일 때, `movieOutput`의 비디오 연결(`connection`)에 `isVideoMirrored` 속성을 활성화했습니다.
```swift
        if let connection = movieOutput.connection(with: .video) {
            if connection.isVideoMirroringSupported {
                connection.isVideoMirrored = position == .front
            }
        }
```

## 📍 PR Point 
> 추후에 이렇게 카메라 속성을 변경하는 것들을 따로 분리해도 좋을 것 같다는 생각을 했습니다! 

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
