### PR TITLE
✨ [Feat] #48 카메라 수평계 기능 구현

### DIFF
--- a/Chalkak/Presentation/Camera/CameraView.swift
+++ b/Chalkak/Presentation/Camera/CameraView.swift
@@ -26,7 +26,7 @@ struct CameraView: View {
                     Spacer()
                     Rectangle()
                         .frame(height: 2)
-                        .foregroundColor(viewModel.isLevel ? .green : .gray)
+                        .foregroundColor(viewModel.isHorizontal ? .green : .gray)
                     Spacer()
                 }
                 .padding(.horizontal, 100)

--- a/Chalkak/Presentation/Camera/CameraView.swift
+++ b/Chalkak/Presentation/Camera/CameraView.swift
@@ -21,6 +21,17 @@ struct CameraView: View {
         ZStack {
             CameraPreviewView(session: viewModel.session, showGrid: $viewModel.isGrid)
 
+            if viewModel.isHorizontalLevelActive {
+                HStack {
+                    Spacer()
+                    Rectangle()
+                        .frame(height: 2)
+                        .foregroundColor(viewModel.isLevel ? .green : .gray)
+                    Spacer()
+                }
+                .padding(.horizontal, 100)
+            }
+
             VStack {
                 CameraTopControlView(viewModel: viewModel)
 

--- a/Chalkak/Presentation/Camera/SubViews/CameraBaseFeatureSelectView.swift
+++ b/Chalkak/Presentation/Camera/SubViews/CameraBaseFeatureSelectView.swift
@@ -22,8 +22,7 @@ struct CameraBaseFeatureSelectView: View {
 
         CircleIconButton(
             iconName: "ruler",
-            action: {},
-            isSelected: false
+            action: viewModel.switchHorizontalLevel, isSelected: viewModel.isHorizontalLevelActive
         )
         .frame(maxWidth: .infinity)
     }


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #48 

## ✨ PR Content
> `CMMotionManager`서 `roll` 프로퍼티를 통해서 현재 카메라의 수평을 확인하고 이에따라
`CameraView`에서 `Rectangle`로 화면 중앙 수평선을 표기


## 📸 Screenshot

https://github.com/user-attachments/assets/1ed476c1-9292-4112-b658-fc44c2d58510


## 📍 PR Point 
> 지금 수평계 기능은 카메라에 포함되어서 `CameraViewModel`에 수평을 판단하는 로직이 존재하는데, 
카메라 기능에 속하면서도 카메라 AVFoundation기능이 아닌지라, tiltManager를 확장해서 같이 묶이는거는 불필요한 방식일지 궁금합니다! 


## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
