### PR TITLE
✨ [Feat] #52 NotificationCenter 로직 Combine 로직으로 변경

### DIFF
--- a/Chalkak/Core/CameraKit/CameraManager.swift
+++ b/Chalkak/Core/CameraKit/CameraManager.swift
@@ -76,14 +76,6 @@ class CameraManager: NSObject, ObservableObject {
                 DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                     self?.session.startRunning()
                 }
-                
-                // 포커스 제스처 알림 구독
-                NotificationCenter.default.addObserver(
-                    self,
-                    selector: #selector(focusAtPoint),
-                    name: .init("FocusAtPoint"),
-                    object: nil
-                )
             } catch {
                 print("카메라 설정 오류: \(error)")
             }
@@ -113,8 +105,7 @@ class CameraManager: NSObject, ObservableObject {
     }
 
     /// 터치한 위치에대한 초점조정
-    @objc func focusAtPoint(_ notification: Notification) {
-        guard let point = notification.userInfo?["point"] as? CGPoint else { return }
+    func focusAtPoint(_ point: CGPoint) {
         guard let device = videoDeviceInput?.device else { return }
 
         do {

--- a/Chalkak/Presentation/Camera/CameraView.swift
+++ b/Chalkak/Presentation/Camera/CameraView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct CameraView: View {
     let isFirstShoot: Bool
     let guide: Guide?
-    
+
     @ObservedObject var viewModel: CameraViewModel
     @EnvironmentObject private var coordinator: Coordinator
 
@@ -40,12 +40,9 @@ struct CameraView: View {
                 CameraBottomControlView(viewModel: viewModel)
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: .init("VideoSaved"))) { output in
-            /// 촬영 완료 후 저장된 파일 URL을 NotificationCenter에서 받고 navigateToEdit 트리거
-            if let userInfo = output.userInfo, let url = userInfo["url"] as? URL {
-                self.clipUrl = url
-                coordinator.push(.clipEdit(clipURL: url, isFirstShoot: isFirstShoot, guide: guide))
-            }
+        .onReceive(viewModel.videoSavedPublisher) { url in
+            self.clipUrl = url
+            coordinator.push(.clipEdit(clipURL: url, isFirstShoot: isFirstShoot, guide: guide))
         }
     }
 }

--- a/Chalkak/Presentation/Camera/CameraView.swift
+++ b/Chalkak/Presentation/Camera/CameraView.swift
@@ -19,7 +19,7 @@ struct CameraView: View {
 
     var body: some View {
         ZStack {
-            CameraPreviewView(session: viewModel.session, showGrid: $viewModel.isGrid)
+            CameraPreviewView(session: viewModel.session, showGrid: $viewModel.isGrid, tabToFocus: viewModel.focusAtPoint)
 
             if viewModel.isHorizontalLevelActive {
                 HStack {

--- a/Chalkak/Presentation/Camera/CameraViewModel.swift
+++ b/Chalkak/Presentation/Camera/CameraViewModel.swift
@@ -18,6 +18,9 @@ class CameraViewModel: ObservableObject {
     let session: AVCaptureSession
     private var tiltCollector = TiltDataCollector()
     private var cancellables = Set<AnyCancellable>()
+    
+    // 비디오 저장 완료 이벤트를 View로 전달
+    let videoSavedPublisher = PassthroughSubject<URL, Never>()
 
     @Published var isTimerRunning = false
     @Published var showingTimerControl = false
@@ -76,6 +79,13 @@ class CameraViewModel: ObservableObject {
 
         model.$isRecording
             .assign(to: &$isRecording)
+        
+        // 비디오 저장상태 구독
+        model.savedVideoInfo
+            .sink { [weak self] url in
+                self?.videoSavedPublisher.send(url)
+            }
+            .store(in: &cancellables)
 
         configure()
     }

--- a/Chalkak/Presentation/Camera/CameraViewModel.swift
+++ b/Chalkak/Presentation/Camera/CameraViewModel.swift
@@ -118,6 +118,11 @@ class CameraViewModel: ObservableObject {
         }
     }
 
+    func focusAtPoint(_ point: CGPoint) {
+        print(point)
+        model.focusAtPoint(point)
+    }
+
     func switchTorch() {
         isTorch.toggle()
         model.setTorchMode(isTorch)

--- a/Chalkak/Presentation/Camera/Preview/CameraPreviewView.swift
+++ b/Chalkak/Presentation/Camera/Preview/CameraPreviewView.swift
@@ -10,9 +10,12 @@ import SwiftUI
 struct CameraPreviewView: UIViewRepresentable {
     let session: AVCaptureSession
     @Binding var showGrid: Bool
+    let tabToFocus: ((CGPoint) -> Void)?
     
     class VideoPreviewView: UIView {
         var gridLayer: CAShapeLayer?
+        var handleFocus: ((CGPoint) -> Void)?
+        
         override class var layerClass: AnyClass {
             AVCaptureVideoPreviewLayer.self
         }
@@ -30,12 +33,7 @@ struct CameraPreviewView: UIViewRepresentable {
             
             showFocusBox(at: location)
             
-            // 초점 조정알림
-            NotificationCenter.default.post(
-                name: .init("FocusAtPoint"),
-                object: nil,
-                userInfo: ["point": devicePoint]
-            )
+            handleFocus?(devicePoint)
         }
         
         // focusbox 표시
@@ -140,6 +138,7 @@ struct CameraPreviewView: UIViewRepresentable {
         view.videoPreviewLayer.videoGravity = .resizeAspect
         view.videoPreviewLayer.cornerRadius = 0
         view.videoPreviewLayer.connection?.videoRotationAngle = 90
+        view.handleFocus = tabToFocus // 콜백 설정
 
         return view
     }


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #52 

## ✨ PR Content
> NotificationCenter를 통해서 소통하던 초점 / 노출 조절 로직과 ClipEidtView(편집페이지)로 URL 넘겨주기위한  비디오저장 로직을 Combine 로직으로 변경하였습니다.

## 📍 PR Point

```swift
let savedVideoInfo = PassthroughSubject<URL, Never>()
```
 
`@Published` 대신에 `PassThorughSubject` 퍼블리셔를 사용했습니다. 
방금찍은 영상의 URL을 상시 저장할 필요없이 단발성 이벤트로 방금찍은것을 filemanger에 1차적으로 저장하고, 저장과정에서 나온 url을  clipEditView로 보내기 위한 것이기 때문에, 값을 유지할필요없이 clipEditView에  전달하는 역할에 좀 더 충실할 수 있게 구성했습니다.

> 대신 PassthroughSubject는 구독 이후에 발행된 값만 받을 수 있는데, 
`CameraViewModel.swft` 에서 초기화시점에 미리 구독을 하기 때문에 문제없이 활용이 가능합니다..! 

```swift
init() {
        model = CameraManager()
        session = model.session

        model.$isRecording
            .assign(to: &$isRecording)
        
        // 비디오 저장상태 구독
        model.savedVideoInfo
            .sink { [weak self] url in
                self?.videoSavedPublisher.send(url)
            }
            .store(in: &cancellables)

        configure()
    }
```

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
