### PR TITLE
🐛 [Fix] #56 카메라 세팅시점에 줌스케일 1.0으로 고정

### DIFF
--- a/Chalkak/Core/CameraKit/CameraManager.swift
+++ b/Chalkak/Core/CameraKit/CameraManager.swift
@@ -75,6 +75,9 @@ class CameraManager: NSObject, ObservableObject {
 
                 DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                     self?.session.startRunning()
+                    DispatchQueue.main.async {
+                        self?.setZoomScale(1.0)
+                    }
                 }
                 
                 // 포커스 제스처 알림 구독


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #56 

## ✨ PR Content
> 카메라 세팅 시점에 줌 스케일이 1.0으로 나와있지만, 사실 0.5배율이었던 문제를 해결했습니다.

## 📍 PR Point 
`setUpCamera`시점에 카메라 Zoom이 1.0으로 고정될 수 있게 수정했습니다. 추후에 설정을 저장해서 카메라 셋업 시점에 적용하게 되면 해당 부분이 다른 설정들을 포함한 메소드로 변경될 것 같습니다 ! 
```swift
  DispatchQueue.main.async {
                        self?.setZoomScale(1.0)
                    }
```

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
