### PR TITLE
🐛 [Fix] #59 초점/노출 조정 로직 적용 순서 변경

### DIFF
--- a/Chalkak/Core/CameraKit/CameraManager.swift
+++ b/Chalkak/Core/CameraKit/CameraManager.swift
@@ -108,27 +108,23 @@ class CameraManager: NSObject, ObservableObject {
         }
     }
 
-    /// 터치한 위치에대한 초점조정
+    /// 터치한 위치값에 대한 초점을 조정하는 메소드
     func focusAtPoint(_ point: CGPoint) {
         guard let device = videoDeviceInput?.device else { return }
 
         do {
             try device.lockForConfiguration()
 
-            if device.isFocusModeSupported(.autoFocus) {
-                device.focusMode = .autoFocus
-                device.focusPointOfInterest = point
-            }
+            // 초점,노출 지점접근
+            device.focusPointOfInterest = point
+            device.exposurePointOfInterest = point
 
-            if device.isExposureModeSupported(.autoExpose) {
-                device.exposureMode = .autoExpose
-                device.exposurePointOfInterest = point
-            }
+            device.focusMode = .autoFocus
+            device.exposureMode = .autoExpose
 
             device.unlockForConfiguration()
-
         } catch {
-            print("초점 에러\(error)")
+            print("디바이스 설정 변경오류\(error)")
         }
     }
 

--- a/Chalkak/Core/CameraKit/CameraManager.swift
+++ b/Chalkak/Core/CameraKit/CameraManager.swift
@@ -76,14 +76,6 @@ class CameraManager: NSObject, ObservableObject {
                 DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                     self?.session.startRunning()
                 }
-                
-                // 포커스 제스처 알림 구독
-                NotificationCenter.default.addObserver(
-                    self,
-                    selector: #selector(focusAtPoint),
-                    name: .init("FocusAtPoint"),
-                    object: nil
-                )
             } catch {
                 print("카메라 설정 오류: \(error)")
             }
@@ -113,8 +105,7 @@ class CameraManager: NSObject, ObservableObject {
     }
 
     /// 터치한 위치에대한 초점조정
-    @objc func focusAtPoint(_ notification: Notification) {
-        guard let point = notification.userInfo?["point"] as? CGPoint else { return }
+    func focusAtPoint(_ point: CGPoint) {
         guard let device = videoDeviceInput?.device else { return }
 
         do {

--- a/Chalkak/Presentation/Camera/CameraView.swift
+++ b/Chalkak/Presentation/Camera/CameraView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct CameraView: View {
     let isFirstShoot: Bool
     let guide: Guide?
-    
+
     @ObservedObject var viewModel: CameraViewModel
     @EnvironmentObject private var coordinator: Coordinator
 
@@ -40,12 +40,9 @@ struct CameraView: View {
                 CameraBottomControlView(viewModel: viewModel)
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: .init("VideoSaved"))) { output in
-            /// 촬영 완료 후 저장된 파일 URL을 NotificationCenter에서 받고 navigateToEdit 트리거
-            if let userInfo = output.userInfo, let url = userInfo["url"] as? URL {
-                self.clipUrl = url
-                coordinator.push(.clipEdit(clipURL: url, isFirstShoot: isFirstShoot, guide: guide))
-            }
+        .onReceive(viewModel.videoSavedPublisher) { url in
+            self.clipUrl = url
+            coordinator.push(.clipEdit(clipURL: url, isFirstShoot: isFirstShoot, guide: guide))
         }
     }
 }

--- a/Chalkak/Presentation/Camera/CameraView.swift
+++ b/Chalkak/Presentation/Camera/CameraView.swift
@@ -19,7 +19,7 @@ struct CameraView: View {
 
     var body: some View {
         ZStack {
-            CameraPreviewView(session: viewModel.session, showGrid: $viewModel.isGrid)
+            CameraPreviewView(session: viewModel.session, showGrid: $viewModel.isGrid, tabToFocus: viewModel.focusAtPoint)
 
             if viewModel.isHorizontalLevelActive {
                 HStack {

--- a/Chalkak/Presentation/Camera/CameraViewModel.swift
+++ b/Chalkak/Presentation/Camera/CameraViewModel.swift
@@ -18,6 +18,9 @@ class CameraViewModel: ObservableObject {
     let session: AVCaptureSession
     private var tiltCollector = TiltDataCollector()
     private var cancellables = Set<AnyCancellable>()
+    
+    // 비디오 저장 완료 이벤트를 View로 전달
+    let videoSavedPublisher = PassthroughSubject<URL, Never>()
 
     @Published var isTimerRunning = false
     @Published var showingTimerControl = false
@@ -76,6 +79,13 @@ class CameraViewModel: ObservableObject {
 
         model.$isRecording
             .assign(to: &$isRecording)
+        
+        // 비디오 저장상태 구독
+        model.savedVideoInfo
+            .sink { [weak self] url in
+                self?.videoSavedPublisher.send(url)
+            }
+            .store(in: &cancellables)
 
         configure()
     }

--- a/Chalkak/Presentation/Camera/CameraViewModel.swift
+++ b/Chalkak/Presentation/Camera/CameraViewModel.swift
@@ -118,6 +118,11 @@ class CameraViewModel: ObservableObject {
         }
     }
 
+    func focusAtPoint(_ point: CGPoint) {
+        print(point)
+        model.focusAtPoint(point)
+    }
+
     func switchTorch() {
         isTorch.toggle()
         model.setTorchMode(isTorch)

--- a/Chalkak/Presentation/Camera/CameraViewModel.swift
+++ b/Chalkak/Presentation/Camera/CameraViewModel.swift
@@ -18,7 +18,7 @@ class CameraViewModel: ObservableObject {
     let session: AVCaptureSession
     private var tiltCollector = TiltDataCollector()
     private var cancellables = Set<AnyCancellable>()
-    
+
     // 비디오 저장 완료 이벤트를 View로 전달
     let videoSavedPublisher = PassthroughSubject<URL, Never>()
 
@@ -79,7 +79,7 @@ class CameraViewModel: ObservableObject {
 
         model.$isRecording
             .assign(to: &$isRecording)
-        
+
         // 비디오 저장상태 구독
         model.savedVideoInfo
             .sink { [weak self] url in
@@ -129,7 +129,6 @@ class CameraViewModel: ObservableObject {
     }
 
     func focusAtPoint(_ point: CGPoint) {
-        print(point)
         model.focusAtPoint(point)
     }
 

--- a/Chalkak/Presentation/Camera/Preview/CameraPreviewView.swift
+++ b/Chalkak/Presentation/Camera/Preview/CameraPreviewView.swift
@@ -138,7 +138,7 @@ struct CameraPreviewView: UIViewRepresentable {
         view.videoPreviewLayer.videoGravity = .resizeAspect
         view.videoPreviewLayer.cornerRadius = 0
         view.videoPreviewLayer.connection?.videoRotationAngle = 90
-        view.handleFocus = tabToFocus // 콜백 설정
+        view.handleFocus = tabToFocus
 
         return view
     }

--- a/Chalkak/Presentation/Camera/Preview/CameraPreviewView.swift
+++ b/Chalkak/Presentation/Camera/Preview/CameraPreviewView.swift
@@ -10,9 +10,12 @@ import SwiftUI
 struct CameraPreviewView: UIViewRepresentable {
     let session: AVCaptureSession
     @Binding var showGrid: Bool
+    let tabToFocus: ((CGPoint) -> Void)?
     
     class VideoPreviewView: UIView {
         var gridLayer: CAShapeLayer?
+        var handleFocus: ((CGPoint) -> Void)?
+        
         override class var layerClass: AnyClass {
             AVCaptureVideoPreviewLayer.self
         }
@@ -30,12 +33,7 @@ struct CameraPreviewView: UIViewRepresentable {
             
             showFocusBox(at: location)
             
-            // 초점 조정알림
-            NotificationCenter.default.post(
-                name: .init("FocusAtPoint"),
-                object: nil,
-                userInfo: ["point": devicePoint]
-            )
+            handleFocus?(devicePoint)
         }
         
         // focusbox 표시
@@ -140,6 +138,7 @@ struct CameraPreviewView: UIViewRepresentable {
         view.videoPreviewLayer.videoGravity = .resizeAspect
         view.videoPreviewLayer.cornerRadius = 0
         view.videoPreviewLayer.connection?.videoRotationAngle = 90
+        view.handleFocus = tabToFocus // 콜백 설정
 
         return view
     }


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #59 

## ✨ PR Content
> 초점 및 노출 설정 시 지원 여부 체크를 제거하고, 기본적으로 autoFocus / autoExpose를 적용하도록 로직 간소화
- 초점/노출 지점 설정과 모드 적용의 순서를 조정하였습니다.

## 📍 PR Point 

> 초점/노출 설정 순서를 focusMode → focusPointOfInterest에서 focusPointOfInterest → focusMode 순으로 변경했습니다.

- `focusPointOfInterest` : 초점을 맞출 위치 지정
- `focusMode` : `focusPointOfInterest`가 지정하고 있는 지점을 기준으로 초점 조정

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
