### PR TITLE
 ✨ [Feat] #64 동영상 촬영 60fps 설정

### DIFF
--- a/Chalkak/Core/CameraKit/CameraManager.swift
+++ b/Chalkak/Core/CameraKit/CameraManager.swift
@@ -36,6 +36,10 @@ class CameraManager: NSObject, ObservableObject {
     @Published var isRecording = false
     @Published var currentZoomScale: CGFloat = 1.0
 
+    // 전면/후면 카메라별 줌 스케일 저장
+    private var frontCameraZoomScale: CGFloat = 1.0
+    private var backCameraZoomScale: CGFloat = 1.0
+
     deinit {
         session.stopRunning()
     }

--- a/Chalkak/Core/CameraKit/CameraManager.swift
+++ b/Chalkak/Core/CameraKit/CameraManager.swift
@@ -48,8 +48,7 @@ class CameraManager: NSObject, ObservableObject {
         // 카메라 기기가 지원하는 모든 포맷들을 하나씩 검사
         for format in device.formats {
             /// 현재 촬영하고자하는 해상도 정보 추출
-            /// dimension.width // Int32
-            /// dimension.height // Int32
+            /// struct CMVideoDimensions { var width: Int32 / var height: Int32 }
             let dimensions = CMVideoFormatDescriptionGetDimensions(format.formatDescription)
             let currentResolution = dimensions.width * dimensions.height
 
@@ -159,15 +158,15 @@ class CameraManager: NSObject, ObservableObject {
     }
 
     /// 켜져있는 플래쉬는 Torch로 표현
-    func setTorchMode(_ isFlash: Bool) {
+    func setTorchMode(_ isTorch: Bool) {
         guard let device = videoDeviceInput?.device else { return }
 
         do {
             try device.lockForConfiguration()
 
             if device.hasTorch, device.isTorchAvailable {
-                device.torchMode = isFlash ? .on : .off
-                if isFlash {
+                device.torchMode = isTorch ? .on : .off
+                if isTorch {
                     try device.setTorchModeOn(level: 1.0)
                 }
             } else {

--- a/Chalkak/Core/CameraKit/CameraManager.swift
+++ b/Chalkak/Core/CameraKit/CameraManager.swift
@@ -40,6 +40,56 @@ class CameraManager: NSObject, ObservableObject {
         session.stopRunning()
     }
 
+    /// 지원하는 최대 1080p , 60fps포맷을 찾아서 설정
+    private func configureFrameRate(for device: AVCaptureDevice) {
+        var targetFormat: AVCaptureDevice.Format?
+        var maxResolution: Int32 = 0
+
+        // 카메라 기기가 지원하는 모든 포맷들을 하나씩 검사
+        for format in device.formats {
+            /// 현재 촬영하고자하는 해상도 정보 추출
+            /// dimension.width // Int32
+            /// dimension.height // Int32
+            let dimensions = CMVideoFormatDescriptionGetDimensions(format.formatDescription)
+            let currentResolution = dimensions.width * dimensions.height
+
+            // 4K까지는 의미X 1080p(1920x1080의값2,073,600)이하로 제한
+            if currentResolution <= 2073600 {
+                // 이 포맷이 지원하는 프레임레이트 범위들을 확인
+                for range in format.videoSupportedFrameRateRanges {
+                    // 지금까지 찾은 것보다 더 높은 해상도인지 확인
+                    if range.maxFrameRate >= 60, currentResolution > maxResolution {
+                        targetFormat = format
+                        maxResolution = currentResolution
+                        break // 60fps 찾으면 break
+                    }
+                }
+            }
+        }
+
+        // 조건에 맞는 포맷을 찾지 못한 경우 에러 처리
+        guard let format = targetFormat else {
+            print("현재 해상도에서 60fps를 지원하지 않습니다.")
+            return
+        }
+
+        // 찾은 최적 포맷을 실제 카메라에 적용
+        do {
+            try device.lockForConfiguration()
+            device.activeFormat = format // 선택된 포맷 적용
+
+            // 프레임 60fps로 고정 설정
+            let frameDuration = CMTime(value: 1, timescale: 60)
+            // 최대 - 최소 프레임 60fps
+            device.activeVideoMinFrameDuration = frameDuration
+            device.activeVideoMaxFrameDuration = frameDuration
+            device.unlockForConfiguration()
+
+        } catch {
+            print("프레임 설정 오류 \(error)")
+        }
+    }
+
     /// 후면 카메라 중 가장 좋은 성능의 카메라(가상 카메라 우선)를 찾아서 반환
     private func findBestBackCamera() -> AVCaptureDevice? {
         let deviceTypes: [AVCaptureDevice.DeviceType] = [
@@ -56,7 +106,12 @@ class CameraManager: NSObject, ObservableObject {
         return discoverySession.devices.first
     }
 
+    /// 카메라 세팅
+    /// 비디오,오디오 연결
     func setUpCamera() {
+        // 고화질 설정
+//        session.sessionPreset = .hd1920x1080
+
         if let device = findBestBackCamera() {
             do {
                 // 카메라 연결
@@ -64,6 +119,8 @@ class CameraManager: NSObject, ObservableObject {
                 if session.canAddInput(videoDeviceInput) {
                     session.addInput(videoDeviceInput)
                 }
+
+                configureFrameRate(for: device)
 
                 // 오디오 입력 추가
                 if let audioDevice = AVCaptureDevice.default(for: .audio) {
@@ -169,6 +226,7 @@ class CameraManager: NSObject, ObservableObject {
                 if session.canAddInput(videoDeviceInput) {
                     session.addInput(videoDeviceInput)
                 }
+                configureFrameRate(for: device)
             } catch {
                 print("카메라 전환 중 오류: \(error)")
             }

--- a/Chalkak/Core/VideoEditor/VideoMerger.swift
+++ b/Chalkak/Core/VideoEditor/VideoMerger.swift
@@ -222,7 +222,8 @@ struct VideoMerger {
             height: videoTrack.naturalSize.width
         )
         videoComposition.instructions = [instructions]
-        videoComposition.frameDuration = CMTimeMake(value: 1, timescale: 30)
+        // 내보내기 사양 60fps 설정
+        videoComposition.frameDuration = CMTimeMake(value: 1, timescale: 60)
         
         return videoComposition
     }

--- a/Chalkak/Presentation/Camera/CameraViewModel.swift
+++ b/Chalkak/Presentation/Camera/CameraViewModel.swift
@@ -233,6 +233,8 @@ class CameraViewModel: ObservableObject {
     func changeCamera() {
         cameraPostion = cameraPostion == .back ? .front : .back
         model.switchCamera(to: cameraPostion)
+        // 카메라 전환 후 CameraManager에서 복원된 줌 스케일을 동기화
+        zoomScale = model.currentZoomScale
     }
 
     func setBoundingBoxUpdateHandler(_ handler: @escaping ([CGRect]) -> Void) {


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #64 

## ✨ PR Content
- 동영상 촬영시 60fps설정
- 카메라 거듭 전환시 줌배율이 초기화되는 문제 수정

## 📍 PR Point 
- 저희가 놓치고 있었던 부분이 있는데, 바로 전면카메라 동영상 촬영시에는 Zoom In/Out기능이 없는 고정배율이라는 것이었습니다..! 이것에 대해서 의논을 해보면 좋을 것 같습니다.
- 현재 카메라 frame설정함수인 `configureFrameRate`함수에는 카메라의 해상도 포맷 중 1080p 이하이면서 60fps를 지원하는 가장 높은 화질의 포맷을 우선적으로 선택하도록 설정되어 있습니다.

1. 1080p인 1920*1080을 계싼해서 2073600픽셀보다 같거나 작아야 1080p 이상으로 가지않음
2. 그리고 이 조건 중에서 60fps을 지원하는지 `videoSupportedFrameRateRanges`를  순회돌면서 60fps 지원하는지 확인함
```swift
[ AVFrameRateRange(minFrameRate: 30.0, maxFrameRate: 60.0), AVFrameRateRange(minFrameRate: 24.0, maxFrameRate: 30.0)]
```
3. 여기서 .maxFrameRate가 60이상을 지원하면 거기서 `maxResolution`을 계속 갱신해주면서 제일 높은 화질(1080이하)이면서 60fps이 지원이 되는 상태로 세팅이 가능
```swift
// 카메라 기기가 지원하는 모든 포맷들을 하나씩 검사
        for format in device.formats {
            /// 현재 촬영하고자하는 해상도 정보 추출
            /// struct CMVideoDimensions { var width: Int32 / var height: Int32 }
            let dimensions = CMVideoFormatDescriptionGetDimensions(format.formatDescription)
            let currentResolution = dimensions.width * dimensions.height

            // 4K까지는 의미X 1080p(1920x1080의값2,073,600)이하로 제한
            if currentResolution <= 2073600 {
                // 이 포맷이 지원하는 프레임레이트 범위들을 확인
                for range in format.videoSupportedFrameRateRanges {
                    // 지금까지 찾은 것보다 더 높은 해상도인지 확인
                    if range.maxFrameRate >= 60, currentResolution > maxResolution {
                        targetFormat = format
                        maxResolution = currentResolution
                        break // 60fps 찾으면 break
                    }
                }
            }
        }
```
초기에는 기존 나와있는대로 다음과같은 기본 프레임만 건드리는 함수였으나, 이렇게 함수를 설정했을때 예기치못하게 화질이 144p 수준으로 떨어지는 문제가 있어서 일단 강제로 1080p 이하 중 가장 높은 화질로 맞춘뒤에, 60fps로 맞추는 로직이 전반부에 수행되게끔 하였습니다. 
```swift
try device.lockForConfiguration()
            device.activeFormat = format 

            // 프레임 60fps로 고정 설정
            let frameDuration = CMTime(value: 1, timescale: 60)
            // 최대 - 최소 프레임 60fps
            device.activeVideoMinFrameDuration = frameDuration
            device.activeVideoMaxFrameDuration = frameDuration
            device.unlockForConfiguration()
```
이에 따라, frame 설정 전에 해상도 포맷을 명시적으로 1080p 이하 중 가장 높은 화질로 설정한 후, 프레임을 60fps로 고정하는 방식으로 수정하였습니다.

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
