### PR TITLE
✨ [Feat] #78 줌인 아웃/핀치 제스쳐

### DIFF
--- a/Chalkak/Core/CameraKit/CameraManager.swift
+++ b/Chalkak/Core/CameraKit/CameraManager.swift
@@ -43,7 +43,8 @@ class CameraManager: NSObject, ObservableObject {
     private var initialCameraPosition: AVCaptureDevice.Position {
         get {
             if let savedValue = UserDefaults.standard.string(forKey: UserDefaultKey.cameraPosition),
-                   savedValue == "front" {
+               savedValue == "front"
+            {
                 return .front
             } else {
                 return .back
@@ -54,14 +55,14 @@ class CameraManager: NSObject, ObservableObject {
             UserDefaults.standard.set(value, forKey: UserDefaultKey.cameraPosition)
         }
     }
-    
+
     deinit {
         session.stopRunning()
     }
-    
+
     override init() {
-            super.init()
-        }
+        super.init()
+    }
 
     /// 지원하는 최대 1080p , 60fps포맷을 찾아서 설정
     private func configureFrameRate(for device: AVCaptureDevice) {
@@ -171,9 +172,8 @@ class CameraManager: NSObject, ObservableObject {
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                 self?.session.startRunning()
                 DispatchQueue.main.async {
-                        // 최초 카메라 설정 시 1.0 줌배율적용
-                        self?.setZoomScale(self?.backCameraZoomScale ?? 1.0)
-                    self?.setZoomScale(zoomScale ?? 1.0)
+                    // 최초 카메라 설정 시 1.0 줌배율적용
+                    self?.setZoomScale(self?.backCameraZoomScale ?? 1.0)
                 }
             }
         } catch {
@@ -240,7 +240,7 @@ class CameraManager: NSObject, ObservableObject {
                 backCameraZoomScale = currentZoomScale
             }
         }
-        
+
         session.beginConfiguration()
         session.removeInput(videoDeviceInput)
 
@@ -273,13 +273,12 @@ class CameraManager: NSObject, ObservableObject {
         session.commitConfiguration()
 
         // 전환된 카메라의 저장된 줌 스케일 복원
-        if position == .back {
+        if newPosition == .back {
             let savedZoomScale = backCameraZoomScale
             setZoomScale(savedZoomScale)
         }
-
     }
-    
+
     /// 줌 배율 설정 (가상 카메라를 사용하여 끊김 없는 줌)
     func setZoomScale(_ scale: CGFloat) {
         guard let device = videoDeviceInput?.device else { return }

--- a/Chalkak/Core/CameraKit/CameraManager.swift
+++ b/Chalkak/Core/CameraKit/CameraManager.swift
@@ -38,8 +38,7 @@ class CameraManager: NSObject, ObservableObject {
     @Published var isRecording = false
     @Published var currentZoomScale: CGFloat = 1.0
 
-    // 전면/후면 카메라별 줌 스케일 저장
-    private var frontCameraZoomScale: CGFloat = 1.0
+    // 카메라 줌스케일
     private var backCameraZoomScale: CGFloat = 1.0
 
     deinit {
@@ -164,7 +163,6 @@ class CameraManager: NSObject, ObservableObject {
         }
     }
 
-
     /// 토치 모드 설정
     func setTorchMode(_ mode: TorchMode) {
         torchMode = mode
@@ -221,9 +219,7 @@ class CameraManager: NSObject, ObservableObject {
     func switchCamera(to position: AVCaptureDevice.Position) {
         // 현재 카메라의 줌 스케일 저장
         if let currentDevice = videoDeviceInput?.device {
-            if currentDevice.position == .front {
-                frontCameraZoomScale = currentZoomScale
-            } else if currentDevice.position == .back {
+            if currentDevice.position == .back {
                 backCameraZoomScale = currentZoomScale
             }
         }
@@ -254,6 +250,7 @@ class CameraManager: NSObject, ObservableObject {
         }
 
         if let connection = movieOutput.connection(with: .video) {
+            // 전면카메라 좌우반전 제거
             if connection.isVideoMirroringSupported {
                 connection.isVideoMirrored = position == .front
             }
@@ -262,8 +259,10 @@ class CameraManager: NSObject, ObservableObject {
         session.commitConfiguration()
 
         // 전환된 카메라의 저장된 줌 스케일 복원
-        let savedZoomScale = position == .front ? frontCameraZoomScale : backCameraZoomScale
-        setZoomScale(savedZoomScale)
+        if position == .back {
+            let savedZoomScale = backCameraZoomScale
+            setZoomScale(savedZoomScale)
+        }
     }
 
     /// 줌 배율 설정 (가상 카메라를 사용하여 끊김 없는 줌)
@@ -285,9 +284,7 @@ class CameraManager: NSObject, ObservableObject {
             currentZoomScale = scale
 
             // 현재 카메라 포지션에 따라 줌 스케일 저장
-            if device.position == .front {
-                frontCameraZoomScale = scale
-            } else if device.position == .back {
+            if device.position == .back {
                 backCameraZoomScale = scale
             }
 

--- a/Chalkak/Presentation/Camera/CameraView.swift
+++ b/Chalkak/Presentation/Camera/CameraView.swift
@@ -19,12 +19,12 @@ struct CameraView: View {
     var body: some View {
         ZStack {
             CameraPreviewView(
-                session: viewModel.session, 
-                showGrid: $viewModel.isGrid, 
+                session: viewModel.session,
                 tabToFocus: viewModel.focusAtPoint,
                 onPinchZoom: viewModel.selectZoomScale,
                 currentZoomScale: viewModel.zoomScale,
-                isUsingFrontCamera: viewModel.isUsingFrontCamera
+                isUsingFrontCamera: viewModel.isUsingFrontCamera,
+                showGrid: $viewModel.isGrid
             )
 
             if viewModel.isHorizontalLevelActive {
@@ -49,13 +49,13 @@ struct CameraView: View {
         .onReceive(viewModel.videoSavedPublisher) { url in
             self.clipUrl = url
             let cameraSetting = viewModel.saveCameraSettingToUserDefaults()
-            
+
             coordinator.push(.clipEdit(
                 clipURL: url,
                 guide: guide,
                 cameraSetting: cameraSetting,
                 TimeStampedTiltList: viewModel.timeStampedTiltList
-                )
+            )
             )
         }
     }

--- a/Chalkak/Presentation/Camera/CameraView.swift
+++ b/Chalkak/Presentation/Camera/CameraView.swift
@@ -18,7 +18,13 @@ struct CameraView: View {
 
     var body: some View {
         ZStack {
-            CameraPreviewView(session: viewModel.session, showGrid: $viewModel.isGrid, tabToFocus: viewModel.focusAtPoint)
+            CameraPreviewView(
+                session: viewModel.session, 
+                showGrid: $viewModel.isGrid, 
+                tabToFocus: viewModel.focusAtPoint,
+                onPinchZoom: viewModel.selectZoomScale,
+                currentZoomScale: viewModel.zoomScale
+            )
 
             if viewModel.isHorizontalLevelActive {
                 HStack {

--- a/Chalkak/Presentation/Camera/CameraView.swift
+++ b/Chalkak/Presentation/Camera/CameraView.swift
@@ -23,7 +23,8 @@ struct CameraView: View {
                 showGrid: $viewModel.isGrid, 
                 tabToFocus: viewModel.focusAtPoint,
                 onPinchZoom: viewModel.selectZoomScale,
-                currentZoomScale: viewModel.zoomScale
+                currentZoomScale: viewModel.zoomScale,
+                isUsingFrontCamera: viewModel.isUsingFrontCamera
             )
 
             if viewModel.isHorizontalLevelActive {

--- a/Chalkak/Presentation/Camera/CameraViewModel.swift
+++ b/Chalkak/Presentation/Camera/CameraViewModel.swift
@@ -19,7 +19,6 @@ class CameraViewModel: ObservableObject {
     private var horizontalLevelCancellable: AnyCancellable?
     private var cancellables = Set<AnyCancellable>()
 
-
     // 비디오 저장 완료 이벤트를 View로 전달
     let videoSavedPublisher = PassthroughSubject<URL, Never>()
 
@@ -47,6 +46,7 @@ class CameraViewModel: ObservableObject {
             isUsingFrontCamera = (cameraPostion == .front)
         }
     }
+
     @Published var isRecording = false
     @Published var recordingTime = 0
 
@@ -54,8 +54,7 @@ class CameraViewModel: ObservableObject {
 
     @Published var showingZoomControl = false
     @Published var zoomScale: CGFloat = 1.0
-    
-    var isUsingFrontCamera: Bool = false
+    @Published var isUsingFrontCamera: Bool = false
 
     // 줌 범위  수정 가능
     var minZoomScale: CGFloat { 0.5 }
@@ -79,7 +78,7 @@ class CameraViewModel: ObservableObject {
     private var recordingStartDate: Date?
     var timeStampedTiltList: [TimeStampedTilt] = []
     @Published var tiltCollector = TiltDataCollector()
-    
+
     var formattedTime: String {
         let minutes = recordingTime / 60
         let seconds = recordingTime % 60
@@ -87,6 +86,7 @@ class CameraViewModel: ObservableObject {
     }
 
     // MARK: - init
+
     init() {
         model = CameraManager()
         session = model.session
@@ -197,12 +197,12 @@ class CameraViewModel: ObservableObject {
     private func executeVideoRecording() {
         model.startRecording()
         isRecording = true
-        
+
         // 녹화 시작 시간 기록
         recordingStartDate = Date()
         // 틸트 데이터 초기화
         timeStampedTiltList.removeAll()
-        
+
         // 타이머 시작
         startRecordingTimer()
         startDataCollectionTimer()
@@ -234,19 +234,19 @@ class CameraViewModel: ObservableObject {
             self?.recordingTime += 1
         }
     }
-    
+
     /// Tilt 데이터 수집용 1/3초 타이머
     private func startDataCollectionTimer() {
         dataCollectionTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 3.0, repeats: true, block: { [weak self] _ in
             guard let self = self else { return }
-            
+
             if self.isRecording, let startDate = recordingStartDate {
                 // 경과 시간 계산
                 let recordingTime = Date().timeIntervalSince(startDate)
-                
+
                 // 기울기 값 가져오기
                 let currentTilt = Tilt(degreeX: tiltCollector.gravityX, degreeZ: tiltCollector.gravityZ)
-                
+
                 timeStampedTiltList.append(.init(time: recordingTime, tilt: currentTilt))
             }
         })
@@ -256,7 +256,7 @@ class CameraViewModel: ObservableObject {
         timer?.invalidate()
         timer = nil
     }
-    
+
     private func stopDataCollectionTimer() {
         dataCollectionTimer?.invalidate()
         timer = nil
@@ -278,7 +278,7 @@ class CameraViewModel: ObservableObject {
     func setBoundingBoxUpdateHandler(_ handler: @escaping ([CGRect]) -> Void) {
         model.onMultiBoundingBoxUpdate = handler
     }
-    
+
     func saveCameraSettingToUserDefaults() -> CameraSetting {
         let setting = CameraSetting(
             zoomScale: zoomScale,
@@ -286,7 +286,7 @@ class CameraViewModel: ObservableObject {
             isFrontPosition: isUsingFrontCamera,
             timerSecond: selectedTimerDuration.rawValue
         )
-        
+
         UserDefaults.standard.set(setting.isFrontPosition, forKey: UserDefaultKey.isFrontPosition)
 
         return setting

--- a/Chalkak/Presentation/Camera/Preview/CameraPreviewView.swift
+++ b/Chalkak/Presentation/Camera/Preview/CameraPreviewView.swift
@@ -9,11 +9,11 @@ import SwiftUI
 
 struct CameraPreviewView: UIViewRepresentable {
     let session: AVCaptureSession
-    @Binding var showGrid: Bool
     let tabToFocus: ((CGPoint) -> Void)?
     let onPinchZoom: ((CGFloat) -> Void)?
     let currentZoomScale: CGFloat
     let isUsingFrontCamera: Bool
+    @Binding var showGrid: Bool
     
     class VideoPreviewView: UIView {
         var gridLayer: CAShapeLayer?
@@ -195,7 +195,7 @@ struct CameraPreviewView: UIViewRepresentable {
         // 외부에서 줌 스케일이 변경되었을 때 동기화
         uiView.updateInitialZoomScale(currentZoomScale)
         
-        // 전면 카메라 상태 업데이트
+        // 핀치제스처 막기위한 현재 카메라 포지션 업데이트
         uiView.isUsingFrontCamera = isUsingFrontCamera
     }
 }

--- a/Chalkak/Presentation/Camera/Preview/CameraPreviewView.swift
+++ b/Chalkak/Presentation/Camera/Preview/CameraPreviewView.swift
@@ -13,11 +13,13 @@ struct CameraPreviewView: UIViewRepresentable {
     let tabToFocus: ((CGPoint) -> Void)?
     let onPinchZoom: ((CGFloat) -> Void)?
     let currentZoomScale: CGFloat
+    let isUsingFrontCamera: Bool
     
     class VideoPreviewView: UIView {
         var gridLayer: CAShapeLayer?
         var handleFocus: ((CGPoint) -> Void)?
         var handlePinchZoom: ((CGFloat) -> Void)?
+        var isUsingFrontCamera: Bool = false
         
         private var initialZoomScale: CGFloat = 1.0
         private var lastPinchScale: CGFloat = 1.0
@@ -40,6 +42,11 @@ struct CameraPreviewView: UIViewRepresentable {
         }
         
         @objc private func handlePinchGesture(_ gesture: UIPinchGestureRecognizer) {
+            // 전면 카메라일 때는 핀치 제스처를 무시
+            if isUsingFrontCamera {
+                return
+            }
+            
             // 감도 개선- 줌스케일 40%로 제한
             let zoomSensitivity: CGFloat = 0.4
             // 감도기반 줌스케일 보정값 적용
@@ -187,5 +194,8 @@ struct CameraPreviewView: UIViewRepresentable {
         
         // 외부에서 줌 스케일이 변경되었을 때 동기화
         uiView.updateInitialZoomScale(currentZoomScale)
+        
+        // 전면 카메라 상태 업데이트
+        uiView.isUsingFrontCamera = isUsingFrontCamera
     }
 }

--- a/Chalkak/Presentation/Camera/SubViews/CameraBottomControlView.swift
+++ b/Chalkak/Presentation/Camera/SubViews/CameraBottomControlView.swift
@@ -41,21 +41,22 @@ struct CameraBottomControlView: View {
                     .transition(.move(edge: .trailing).combined(with: .opacity))
                 } else {
                     Spacer()
-
-                    Button(action: {
-                        if !viewModel.isTimerRunning {
-                            viewModel.toggleZoomControl()
+                    if !viewModel.isUsingFrontCamera {
+                        Button(action: {
+                            if !viewModel.isTimerRunning {
+                                viewModel.toggleZoomControl()
+                            }
+                        }) {
+                            VStack(spacing: 2) {
+                                Text(String(format: "%.1fx", viewModel.zoomScale))
+                                    .font(.system(size: 14, weight: .semibold))
+                                    .foregroundColor(.white)
+                            }
+                            .frame(width: 55, height: 55)
+                            .background(Color.black.opacity(0.6))
+                            .clipShape(Circle())
+                            .opacity(viewModel.isTimerRunning ? 0.5 : 1.0)
                         }
-                    }) {
-                        VStack(spacing: 2) {
-                            Text(String(format: "%.1fx", viewModel.zoomScale))
-                                .font(.system(size: 14, weight: .semibold))
-                                .foregroundColor(.white)
-                        }
-                        .frame(width: 55, height: 55)
-                        .background(Color.black.opacity(0.6))
-                        .clipShape(Circle())
-                        .opacity(viewModel.isTimerRunning ? 0.5 : 1.0)
                     }
                 }
             }


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #78 

## ✨ PR Content
- 전면 촬영시  줌 인/아웃 로직 제거
- `UIPinchGestureRecognizer`라는 클래스로 이제 손가락 제스처 인터렉션에 대해서 가져올 수가 있고,
`scale`과 `velocity`에 접근할 수가 있습니다! 
```swift
@MainActor open class UIPinchGestureRecognizer : UIGestureRecognizer 
    open var scale: CGFloat
    open var velocity: CGFloat { get }
}
```

> scale값이 1보다 크면 확대 , 작으면 축소 
> velocity는 사용자 손가락이 얼마나 빠른지를 나타내는 값
**나중에 이걸로 좀 급작스럽게 변하는 줌인아웃에 대해서 좀 보정값을 줄 수 있을 것 같습니다.** 

## 📍 PR Point 
- 지금은 제스처 레코그나이저로 연결이 되어있는데, 이 `UIPinchGestureRecognizer` 를 `combine`으로 연결해줄 수 있을지는 추후에 도전을 해보도록 하겠습니다..! 
- 당장에는 쉽게 변환되는게 아닌것 같더라구요..! 

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
