### PR TITLE
✨ [Feat] CameraSetting 촬영시 유지되도록 구현

### DIFF
--- a/Chalkak/App/ChalkakApp.swift
+++ b/Chalkak/App/ChalkakApp.swift
@@ -37,11 +37,8 @@ struct ChalkakApp: App {
                                 timeStampedTiltList: timeStampedTiltList
                             )
 
-                        case .overlay(let clip, let isFrontCamera):
-                            OverlayView(
-                                clip: clip,
-                                isFrontCamera: isFrontCamera
-                            )
+                        case .overlay(let clip):
+                            OverlayView(clip: clip)
 
                         case .boundingBox(let guide):
                             BoundingBoxView(guide: guide)

--- a/Chalkak/Common/Constant/Environment/UserDefaultKey.swift
+++ b/Chalkak/Common/Constant/Environment/UserDefaultKey.swift
@@ -11,4 +11,5 @@ enum UserDefaultKey {
     static let zoomScale = "zoomScale"
     static let timerSecond = "timerSecond"
     static let isFrontPosition = "isFrontPosition"
+    static let cameraPosition = "cameraPosition"
 }

--- a/Chalkak/Common/Constant/Environment/UserDefaultKey.swift
+++ b/Chalkak/Common/Constant/Environment/UserDefaultKey.swift
@@ -7,5 +7,8 @@
 
 enum UserDefaultKey {
     // CameraSetting
+    static let isGridOn = "isGridOn"
+    static let zoomScale = "zoomScale"
+    static let timerSecond = "timerSecond"
     static let isFrontPosition = "isFrontPosition"
 }

--- a/Chalkak/Common/Util/Enum/Path.swift
+++ b/Chalkak/Common/Util/Enum/Path.swift
@@ -9,7 +9,7 @@ import Foundation
 
 enum Path: Hashable {
     case clipEdit(clipURL: URL, guide: Guide?, cameraSetting: CameraSetting, TimeStampedTiltList: [TimeStampedTilt])
-    case overlay(clip: Clip, isFrontCamera: Bool)
+    case overlay(clip: Clip)
     case boundingBox(guide: Guide)
     case projectPreview(finalVideoURL: URL)
 }

--- a/Chalkak/Core/CameraKit/CameraManager.swift
+++ b/Chalkak/Core/CameraKit/CameraManager.swift
@@ -41,10 +41,27 @@ class CameraManager: NSObject, ObservableObject {
     // 전면/후면 카메라별 줌 스케일 저장
     private var frontCameraZoomScale: CGFloat = 1.0
     private var backCameraZoomScale: CGFloat = 1.0
-
+    private var initialCameraPosition: AVCaptureDevice.Position {
+        get {
+            if let savedValue = UserDefaults.standard.string(forKey: "cameraPosition"), savedValue == "front" {
+                return .front
+            } else {
+                return .back
+            }
+        }
+        set {
+            let value = newValue == .front ? "front" : "back"
+            UserDefaults.standard.set(value, forKey: "cameraPosition")
+        }
+    }
+    
     deinit {
         session.stopRunning()
     }
+    
+    override init() {
+            super.init()
+        }
 
     /// 지원하는 최대 1080p , 60fps포맷을 찾아서 설정
     private func configureFrameRate(for device: AVCaptureDevice) {
@@ -114,56 +131,55 @@ class CameraManager: NSObject, ObservableObject {
     /// 카메라 세팅
     /// 비디오,오디오 연결
     func setUpCamera() {
-        // 고화질 설정
-//        session.sessionPreset = .hd1920x1080
+        let position = initialCameraPosition
+        let device = (position == .back) ? findBestBackCamera() : AVCaptureDevice.default(
+            .builtInWideAngleCamera,
+            for: .video,
+            position: .front
+        )
 
-        if let device = findBestBackCamera() {
-            do {
-                // 카메라 연결
-                videoDeviceInput = try AVCaptureDeviceInput(device: device)
-                if session.canAddInput(videoDeviceInput) {
-                    session.addInput(videoDeviceInput)
-                }
+        guard let device = device else { return }
 
-                configureFrameRate(for: device)
-
-                // 오디오 입력 추가
-                if let audioDevice = AVCaptureDevice.default(for: .audio) {
-                    do {
-                        let audioInput = try AVCaptureDeviceInput(device: audioDevice)
-                        if session.canAddInput(audioInput) {
-                            session.addInput(audioInput)
-                        }
-                    } catch {
-                        print("오디오 장치 입력 설정 오류: \(error)")
-                    }
-                }
-
-                // 동영상 출력 추가
-                if session.canAddOutput(movieOutput) {
-                    session.addOutput(movieOutput)
-                }
-
-                // 비디오 데이터 출력 추가 및 델리게이트 설정
-                if session.canAddOutput(videoOutput) {
-                    session.addOutput(videoOutput)
-                    videoOutput.setSampleBufferDelegate(boundingBoxManager, queue: videoDataOutputQueue)
-                    videoOutput.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
-                }
-
-                DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-                    self?.session.startRunning()
-                    DispatchQueue.main.async {
-                        // 최초 카메라 설정 시 1.0 줌배율적용
-                        self?.setZoomScale(self?.backCameraZoomScale ?? 1.0)
-                    }
-                }
-            } catch {
-                print("카메라 설정 오류: \(error)")
+        do {
+            videoDeviceInput = try AVCaptureDeviceInput(device: device)
+            if session.canAddInput(videoDeviceInput) {
+                session.addInput(videoDeviceInput)
             }
+
+            configureFrameRate(for: device)
+
+            // 오디오 입력 추가
+            if let audioDevice = AVCaptureDevice.default(for: .audio) {
+                let audioInput = try AVCaptureDeviceInput(device: audioDevice)
+                if session.canAddInput(audioInput) {
+                    session.addInput(audioInput)
+                }
+            }
+
+            // 동영상 출력 추가
+            if session.canAddOutput(movieOutput) {
+                session.addOutput(movieOutput)
+            }
+
+            // 비디오 데이터 출력 추가 및 델리게이트 설정
+            if session.canAddOutput(videoOutput) {
+                session.addOutput(videoOutput)
+                videoOutput.setSampleBufferDelegate(boundingBoxManager, queue: videoDataOutputQueue)
+                videoOutput.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
+            }
+
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                self?.session.startRunning()
+                DispatchQueue.main.async {
+                    // 최초 카메라 설정 시 1.0 줌배율 적용
+                    let zoomScale = (position == .front) ? self?.frontCameraZoomScale : self?.backCameraZoomScale
+                    self?.setZoomScale(zoomScale ?? 1.0)
+                }
+            }
+        } catch {
+            print("카메라 설정 오류: \(error)")
         }
     }
-
 
     /// 토치 모드 설정
     func setTorchMode(_ mode: TorchMode) {
@@ -218,8 +234,7 @@ class CameraManager: NSObject, ObservableObject {
     }
 
     /// 전면/후면 카메라 전환
-    func switchCamera(to position: AVCaptureDevice.Position) {
-        // 현재 카메라의 줌 스케일 저장
+    func switchCamera(to newPosition: AVCaptureDevice.Position) {
         if let currentDevice = videoDeviceInput?.device {
             if currentDevice.position == .front {
                 frontCameraZoomScale = currentZoomScale
@@ -227,45 +242,36 @@ class CameraManager: NSObject, ObservableObject {
                 backCameraZoomScale = currentZoomScale
             }
         }
-
+        
         session.beginConfiguration()
+        session.removeInput(videoDeviceInput)
 
-        if let existingInput = videoDeviceInput {
-            session.removeInput(existingInput)
+        let device = (newPosition == .back) ? findBestBackCamera() : AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .front)
+
+        guard let newDevice = device else {
+            session.commitConfiguration()
+            return
         }
 
-        let newDevice: AVCaptureDevice?
-        if position == .back {
-            newDevice = findBestBackCamera()
-        } else {
-            newDevice = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: position)
-        }
-
-        if let device = newDevice {
-            do {
-                videoDeviceInput = try AVCaptureDeviceInput(device: device)
-                if session.canAddInput(videoDeviceInput) {
-                    session.addInput(videoDeviceInput)
-                }
-                configureFrameRate(for: device)
-            } catch {
-                print("카메라 전환 중 오류: \(error)")
+        do {
+            let newInput = try AVCaptureDeviceInput(device: newDevice)
+            if session.canAddInput(newInput) {
+                session.addInput(newInput)
+                videoDeviceInput = newInput
+                configureFrameRate(for: newDevice)
+                initialCameraPosition = newPosition
             }
-        }
-
-        if let connection = movieOutput.connection(with: .video) {
-            if connection.isVideoMirroringSupported {
-                connection.isVideoMirrored = position == .front
-            }
+        } catch {
+            print("카메라 전환 오류: \(error)")
         }
 
         session.commitConfiguration()
 
         // 전환된 카메라의 저장된 줌 스케일 복원
-        let savedZoomScale = position == .front ? frontCameraZoomScale : backCameraZoomScale
+        let savedZoomScale = newPosition == .front ? frontCameraZoomScale : backCameraZoomScale
         setZoomScale(savedZoomScale)
     }
-
+    
     /// 줌 배율 설정 (가상 카메라를 사용하여 끊김 없는 줌)
     func setZoomScale(_ scale: CGFloat) {
         guard let device = videoDeviceInput?.device else { return }

--- a/Chalkak/Core/CameraKit/CameraManager.swift
+++ b/Chalkak/Core/CameraKit/CameraManager.swift
@@ -43,7 +43,8 @@ class CameraManager: NSObject, ObservableObject {
     private var backCameraZoomScale: CGFloat = 1.0
     private var initialCameraPosition: AVCaptureDevice.Position {
         get {
-            if let savedValue = UserDefaults.standard.string(forKey: "cameraPosition"), savedValue == "front" {
+            if let savedValue = UserDefaults.standard.string(forKey: UserDefaultKey.cameraPosition),
+                   savedValue == "front" {
                 return .front
             } else {
                 return .back
@@ -51,7 +52,7 @@ class CameraManager: NSObject, ObservableObject {
         }
         set {
             let value = newValue == .front ? "front" : "back"
-            UserDefaults.standard.set(value, forKey: "cameraPosition")
+            UserDefaults.standard.set(value, forKey: UserDefaultKey.cameraPosition)
         }
     }
     

--- a/Chalkak/Presentation/Camera/CameraViewModel.swift
+++ b/Chalkak/Presentation/Camera/CameraViewModel.swift
@@ -289,9 +289,6 @@ class CameraViewModel: ObservableObject {
             timerSecond: selectedTimerDuration.rawValue
         )
         
-        print("cameraPosition: \(cameraPostion)")
-        print("isFrontPosition: \(setting.isFrontPosition)")
-        print("isFrontPosition: \(setting.isFrontPosition)")
         UserDefaults.standard.set(isGrid, forKey: UserDefaultKey.isGridOn)
         UserDefaults.standard.set(zoomScale, forKey: UserDefaultKey.zoomScale)
         UserDefaults.standard.set(selectedTimerDuration.rawValue, forKey: UserDefaultKey.timerSecond)
@@ -310,12 +307,6 @@ class CameraViewModel: ObservableObject {
         isGrid = savedGridOn
         zoomScale = savedZoomScale
         selectedTimerDuration = TimerOptions(rawValue: savedTimer) ?? .off
-
-//        cameraPostion = savedIsFront ? .front : .back
         cameraPostion = savedIsFront ? .front : .back
-
-        // 카메라 장치도 실제로 전환 필요
-//        model.switchCamera(to: cameraPostion)
-//        model.setZoomScale(zoomScale)
     }
 }

--- a/Chalkak/Presentation/Camera/CameraViewModel.swift
+++ b/Chalkak/Presentation/Camera/CameraViewModel.swift
@@ -101,6 +101,8 @@ class CameraViewModel: ObservableObject {
             }
             .store(in: &cancellables)
 
+        loadSavedSettings()
+        
         configure()
     }
 
@@ -287,8 +289,33 @@ class CameraViewModel: ObservableObject {
             timerSecond: selectedTimerDuration.rawValue
         )
         
+        print("cameraPosition: \(cameraPostion)")
+        print("isFrontPosition: \(setting.isFrontPosition)")
+        print("isFrontPosition: \(setting.isFrontPosition)")
+        UserDefaults.standard.set(isGrid, forKey: UserDefaultKey.isGridOn)
+        UserDefaults.standard.set(zoomScale, forKey: UserDefaultKey.zoomScale)
+        UserDefaults.standard.set(selectedTimerDuration.rawValue, forKey: UserDefaultKey.timerSecond)
         UserDefaults.standard.set(setting.isFrontPosition, forKey: UserDefaultKey.isFrontPosition)
 
         return setting
+    }
+    
+    private func loadSavedSettings() {
+        let savedGridOn = UserDefaults.standard.bool(forKey: UserDefaultKey.isGridOn)
+        let savedZoomScale = UserDefaults.standard.object(forKey: UserDefaultKey.zoomScale) as? CGFloat ?? 0.0
+        let savedTimer = UserDefaults.standard.integer(forKey: UserDefaultKey.timerSecond)
+        let savedIsFront = UserDefaults.standard.bool(forKey: UserDefaultKey.isFrontPosition)
+
+        // 상태에 반영
+        isGrid = savedGridOn
+        zoomScale = savedZoomScale
+        selectedTimerDuration = TimerOptions(rawValue: savedTimer) ?? .off
+
+//        cameraPostion = savedIsFront ? .front : .back
+        cameraPostion = savedIsFront ? .front : .back
+
+        // 카메라 장치도 실제로 전환 필요
+//        model.switchCamera(to: cameraPostion)
+//        model.setZoomScale(zoomScale)
     }
 }

--- a/Chalkak/Presentation/Camera/Preview/CameraPreviewView.swift
+++ b/Chalkak/Presentation/Camera/Preview/CameraPreviewView.swift
@@ -144,6 +144,8 @@ struct CameraPreviewView: UIViewRepresentable {
     }
     
     func updateUIView(_ uiView: VideoPreviewView, context: Context) {
-        showGrid ? uiView.showGrid() : uiView.hideGrid()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            self.showGrid ? uiView.showGrid() : uiView.hideGrid()
+        }
     }
 }

--- a/Chalkak/Presentation/ClipEdit/ClipEditView.swift
+++ b/Chalkak/Presentation/ClipEdit/ClipEditView.swift
@@ -109,10 +109,7 @@ struct ClipEditView: View {
                         editViewModel.saveProjectData()
                         // 오버레이 생성 화면으로 이동
                         coordinator.push(
-                            .overlay(
-                                clip: editViewModel.createClipData(),
-                                isFrontCamera: cameraSetting.isFrontPosition
-                            )
+                            .overlay(clip: editViewModel.createClipData())
                         )
                     } else {
                         // 트리밍한 클립 프로젝트에 추가

--- a/Chalkak/Presentation/Guide/Distance/BoundingBoxViewModel.swift
+++ b/Chalkak/Presentation/Guide/Distance/BoundingBoxViewModel.swift
@@ -40,6 +40,14 @@ class BoundingBoxViewModel: ObservableObject {
         }
     }
     
+    func deleteUserDefault() {
+        UserDefaults.standard.removeObject(forKey: UserDefaultKey.isGridOn)
+        UserDefaults.standard.removeObject(forKey: UserDefaultKey.zoomScale)
+        UserDefaults.standard.removeObject(forKey: UserDefaultKey.timerSecond)
+        UserDefaults.standard.removeObject(forKey: UserDefaultKey.isFrontPosition)
+        UserDefaults.standard.removeObject(forKey: UserDefaultKey.cameraPosition)
+    }
+    
     /// 값 비교
     func compare() {
         guard !referenceBoundingBoxes.isEmpty else { return }

--- a/Chalkak/Presentation/Guide/Distance/SubViews/FirstShootCameraView.swift
+++ b/Chalkak/Presentation/Guide/Distance/SubViews/FirstShootCameraView.swift
@@ -8,11 +8,15 @@
 import SwiftUI
 
 struct FirstShootCameraView: View {
+    @StateObject private var viewModel = BoundingBoxViewModel()
     @StateObject private var cameraViewModel = CameraViewModel()
 
     var body: some View {
         ZStack {
             CameraView(guide: nil, viewModel: cameraViewModel)
+        }
+        .onAppear() {
+            viewModel.deleteUserDefault()
         }
     }
 }

--- a/Chalkak/Presentation/Guide/Overlay/OverlayView.swift
+++ b/Chalkak/Presentation/Guide/Overlay/OverlayView.swift
@@ -30,7 +30,6 @@ import SwiftUI
 struct OverlayView: View {
     // 1. Input properties
     let clip: Clip
-    let isFrontCamera: Bool
 
     // 2. State & ObservedObject
     @StateObject var overlayViewModel: OverlayViewModel
@@ -40,9 +39,8 @@ struct OverlayView: View {
     @State private var guide: Guide?
     
     // 3. init
-    init(clip: Clip, isFrontCamera: Bool) {
+    init(clip: Clip) {
         self.clip = clip
-        self.isFrontCamera = isFrontCamera
         self._overlayViewModel = StateObject(wrappedValue: OverlayViewModel(clip: clip))
     }
     
@@ -80,10 +78,7 @@ struct OverlayView: View {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button("다음") {
                     /// 가이드 객체 생성
-                    if let newGuide = overlayViewModel.makeGuide(
-                        clipID: clip.id,
-                        isFrontCamera: isFrontCamera
-                    ) {
+                    if let newGuide = overlayViewModel.makeGuide(clipID: clip.id) {
                         guide = newGuide
                         coordinator.push(.boundingBox(guide: newGuide))
                     } else {

--- a/Chalkak/Presentation/Guide/Overlay/OverlayViewModel.swift
+++ b/Chalkak/Presentation/Guide/Overlay/OverlayViewModel.swift
@@ -85,7 +85,7 @@ final class OverlayViewModel: ObservableObject {
 
     /// Guide 객체 생성
     @MainActor
-    func makeGuide(clipID: String, isFrontCamera: Bool) -> Guide? {
+    func makeGuide(clipID: String) -> Guide? {
         guard let capturedImage = overlayManager.outlineImage else {
             print("❌ outlineImage가 없습니다.")
             return nil
@@ -94,8 +94,9 @@ final class OverlayViewModel: ObservableObject {
         let cameraTilt = determineTilt()
         
         let outlineImage: UIImage
-        
-        if isFrontCamera {
+        let savedIsFront = UserDefaults.standard.string(forKey: UserDefaultKey.cameraPosition)
+
+        if savedIsFront == "true" {
             outlineImage = capturedImage.flippedHorizontally()
         } else {
             outlineImage = capturedImage


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #85

## ✨ PR Content
> 작업 내용 설명을 적어주세요.

CameraSetting 값들이 다음 촬영에도 이어지도록 UserDefault에 저장했습니다.
하나의 프로젝트 (여러 영상을 찍고 이어붙이기 완료)를 완성하고 아예 새로운 프로젝트를 시작하는 경우에
UserDefault의 CameraSetting 값들을 초기화 합니다.
UserDefault에 저장된 값을 이용하도록 개선함으로써 isFrontCamera 파라미터를 제거했습니다.

## 📸 Screenshot
> 작업 화면의 스크린샷을 추가해주세요.

https://github.com/user-attachments/assets/d644553d-7709-4ecb-a7d8-6097c31e52ab


## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요

- 저장 방식
ViewModel을 통해서 저장되는 로직으로 사용되는게 현재 구현 상태에서 사용하기 좋아보였습니다.
따라서 기존 계획했던 AppStorage가 아닌 UserDefault에 저장하는 방식으로 CameraSetting을 저장합니다.

- UserDefault 초기화
기존에는 UserDefault를 따로 초기화하고 있지 않았습니다.
새로 촬영을 시작하면 UserDefault가 비어있어야 로직이 제대로 동작하기 때문에
첫 촬영으로 카메라에 진입한 시점에 초기화 시켜주었습니다.
(currentProjectID 는 따로 지금 처리하지 않아서 이후 프로젝트 관리 시점에 추가해야 합니다.)

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
