### PR TITLE
🐛 [Fix] 카메라 전환 실패 문제 해결

### DIFF
--- a/Chalkak/Core/CameraKit/CameraManager.swift
+++ b/Chalkak/Core/CameraKit/CameraManager.swift
@@ -259,8 +259,8 @@ class CameraManager: NSObject, ObservableObject {
 
         do {
             let newInput = try AVCaptureDeviceInput(device: newDevice)
-            if session.canAddInput(videoDeviceInput) {
-                session.addInput(videoDeviceInput)
+            if session.canAddInput(newInput) {
+                session.addInput(newInput)
                 videoDeviceInput = newInput
                 configureFrameRate(for: newDevice)
                 initialCameraPosition = newPosition

--- a/Chalkak/Presentation/Camera/CameraViewModel.swift
+++ b/Chalkak/Presentation/Camera/CameraViewModel.swift
@@ -102,8 +102,13 @@ class CameraViewModel: ObservableObject {
             .store(in: &cancellables)
 
         loadSavedSettings()
-        
+
         configure()
+
+        // 저장되어있는 줌스케일 적용
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.model.setZoomScale(self.zoomScale)
+        }
     }
 
     func switchCameraControls() {
@@ -175,10 +180,13 @@ class CameraViewModel: ObservableObject {
     }
 
     func toggleZoomControl() {
+        // 전면 카메라에서 줌 제어 비활성화
+        guard !isUsingFrontCamera else { return }
         showingZoomControl.toggle()
     }
 
     func selectZoomScale(_ scale: CGFloat) {
+        guard !isUsingFrontCamera else { return }
         guard !scale.isNaN, !scale.isInfinite else { return }
 
         let safeScale = max(minZoomScale, min(maxZoomScale, scale))
@@ -271,10 +279,23 @@ class CameraViewModel: ObservableObject {
     }
 
     func changeCamera() {
+        // 후면->전면 전환시 : 현재 줌 저장 후 전면카메라로 전환
+        if cameraPostion == .back {
+            // 후면카메라 줌상태 저장 (UserDefaults)
+            UserDefaults.standard.set(zoomScale, forKey: "backCameraZoomScale")
+            showingZoomControl = false
+            zoomScale = 1.0
+        }
+
         cameraPostion = cameraPostion == .back ? .front : .back
         model.switchCamera(to: cameraPostion)
-        // 카메라 전환 후 CameraManager에서 복원된 줌 스케일을 동기화
-        zoomScale = model.currentZoomScale
+
+        // 전면->후면 전환시 : 이전에 저장된 후면카메라 줌 복원
+        if cameraPostion == .back {
+            let savedZoom = UserDefaults.standard.object(forKey: "backCameraZoomScale") as? CGFloat ?? 1.0
+            zoomScale = savedZoom
+            model.setZoomScale(savedZoom)
+        }
     }
 
     func setBoundingBoxUpdateHandler(_ handler: @escaping ([CGRect]) -> Void) {
@@ -288,7 +309,7 @@ class CameraViewModel: ObservableObject {
             isFrontPosition: isUsingFrontCamera,
             timerSecond: selectedTimerDuration.rawValue
         )
-        
+
         UserDefaults.standard.set(isGrid, forKey: UserDefaultKey.isGridOn)
         UserDefaults.standard.set(zoomScale, forKey: UserDefaultKey.zoomScale)
         UserDefaults.standard.set(selectedTimerDuration.rawValue, forKey: UserDefaultKey.timerSecond)
@@ -296,10 +317,10 @@ class CameraViewModel: ObservableObject {
 
         return setting
     }
-    
+
     private func loadSavedSettings() {
         let savedGridOn = UserDefaults.standard.bool(forKey: UserDefaultKey.isGridOn)
-        let savedZoomScale = UserDefaults.standard.object(forKey: UserDefaultKey.zoomScale) as? CGFloat ?? 0.0
+        let savedZoomScale = UserDefaults.standard.object(forKey: UserDefaultKey.zoomScale) as? CGFloat ?? 1.0
         let savedTimer = UserDefaults.standard.integer(forKey: UserDefaultKey.timerSecond)
         let savedIsFront = UserDefaults.standard.bool(forKey: UserDefaultKey.isFrontPosition)
 

--- a/Chalkak/Presentation/Camera/SubViews/CameraBottomControlView.swift
+++ b/Chalkak/Presentation/Camera/SubViews/CameraBottomControlView.swift
@@ -13,7 +13,7 @@ struct CameraBottomControlView: View {
     var body: some View {
         VStack(spacing: 20) {
             HStack {
-                if viewModel.showingZoomControl && !viewModel.isTimerRunning {
+                if viewModel.showingZoomControl && !viewModel.isTimerRunning && !viewModel.isUsingFrontCamera {
                     HStack(spacing: 15) {
                         ZoomSlider(
                             zoomScale: viewModel.zoomScale,


### PR DESCRIPTION
## 🔖  해결한 이슈 
- #84 머지 충돌 해결 과정에서 비활성화된 카메라 전환 기능 수정

## ✨ PR Content
- 카메라 전환 로직 내 `isUsingFrontCamera`에 대한 예외 처리 추가
- `switchCamera`과정에서 session input 재구성 시 누락된 `newInput` 객체 추가

```swift

        do {
            let newInput = try AVCaptureDeviceInput(device: newDevice)
            if session.canAddInput(newInput) {
                session.addInput(newInput)
                videoDeviceInput = newInput
                configureFrameRate(for: newDevice)
                initialCameraPosition = newPosition
            }

        } catch {
            print("카메라 전환 중 오류: \(error)")
        }
```

## 📍 PR Point 
- 이게 전환 로직을 수정과 함께 줌 배율 수정 슬라이더가 열려있을떼 카메라를 전환하면 여전히 전면에서 줌스케일을 조정할 수 있던 버그도 함께 수정하였습니다. 

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
