### PR TITLE
✨ [Feat] #96 Clip 모델에 originalDuration 추가 및 dataManager 변경

### DIFF
--- a/Chalkak/Data/Model/Clip.swift
+++ b/Chalkak/Data/Model/Clip.swift
@@ -35,6 +35,11 @@ class Clip {
     /// 시간별로 기록된 카메라 높이 정보.
     var heightList: [TimeStampedHeight]
     
+    /// 트리밍된 시간을 계산한 정보.
+    var currentTrimmedDuration: Double {
+        return endPoint - startPoint
+    }
+    
     /// 새로운 Clip 인스턴스를 초기화합니다.
     /// - Parameters:
     ///   - id: 클립의 고유 ID (기본값은 UUID).

--- a/Chalkak/Data/Model/Clip.swift
+++ b/Chalkak/Data/Model/Clip.swift
@@ -17,6 +17,9 @@ class Clip {
     /// 영상의 바이너리 데이터.
     var videoURL: URL
     
+    /// 원본 영상의 총 길이. 클립 생성 시 한 번만 계산.
+    var originalDuration: Double
+    
     /// 트리밍하여 사용할 영상 구간의 시작 시점. (초 단위)
     var startPoint: Double
     
@@ -36,6 +39,7 @@ class Clip {
     /// - Parameters:
     ///   - id: 클립의 고유 ID (기본값은 UUID).
     ///   - videoData: 영상의 데이터.
+    ///   - originalDuration: 원본 영상의 총 길이.
     ///   - startPoint: 시작 시점 (초 단위).
     ///   - endPoint: 종료 시점 (초 단위).
     ///   - createdAt: 생성일자 (기본값은 현재 시각).
@@ -44,6 +48,7 @@ class Clip {
     init(
         id: String = UUID().uuidString,
         videoURL: URL,
+        originalDuration: Double,
         startPoint: Double = 0,
         endPoint: Double,
         createdAt: Date = .now,
@@ -52,6 +57,7 @@ class Clip {
     ) {
         self.id = id
         self.videoURL = videoURL
+        self.originalDuration = originalDuration
         self.startPoint = startPoint
         self.endPoint = endPoint
         self.createdAt = createdAt

--- a/Chalkak/Data/SwiftDataManager.swift
+++ b/Chalkak/Data/SwiftDataManager.swift
@@ -109,6 +109,7 @@ class SwiftDataManager {
     func createClip(
         id: String,
         videoURL: URL,
+        originalDuration: Double,
         startPoint: Double = 0,
         endPoint: Double,
         tiltList: [TimeStampedTilt] = [],
@@ -117,6 +118,7 @@ class SwiftDataManager {
         let clip = Clip(
             id: id,
             videoURL: videoURL,
+            originalDuration: originalDuration,
             startPoint: startPoint,
             endPoint: endPoint,
             tiltList: tiltList,

--- a/Chalkak/Presentation/ClipEdit/ClipEditViewModel.swift
+++ b/Chalkak/Presentation/ClipEdit/ClipEditViewModel.swift
@@ -291,6 +291,7 @@ final class ClipEditViewModel: ObservableObject {
         return Clip(
             id: clipID,
             videoURL: clipURL,
+            originalDuration: duration,
             startPoint: startPoint,
             endPoint: endPoint,
             tiltList: timeStampedTiltList,


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #96

## ✨ PR Content
> 작업 내용 설명을 적어주세요.

프로젝트 단에서 각 개별 클립 편집에 활용하기 위해 
Clip 데이터 모델에 originalDuration 추가 관리하도록 수정했습니다.

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
