### PR TITLE
💄 [style] 네비게이션바 공통 컴포넌트 구현

### DIFF
--- a/Chalkak.xcodeproj/project.pbxproj
+++ b/Chalkak.xcodeproj/project.pbxproj
@@ -77,6 +77,9 @@
 		C5C12EAA2E325A1800C4DC6D /* SolidButtonStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C12EA92E325A1800C4DC6D /* SolidButtonStyler.swift */; };
 		C5C12EAC2E325A3B00C4DC6D /* IconButtonStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C12EAB2E325A3B00C4DC6D /* IconButtonStyler.swift */; };
 		C5C12EAE2E325A5800C4DC6D /* GlassButtonStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C12EAD2E325A5800C4DC6D /* GlassButtonStyler.swift */; };
+		C5C12EB12E33684F00C4DC6D /* SnappieNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C12EB02E33684F00C4DC6D /* SnappieNavigationBar.swift */; };
+		C5C12EB42E3380B900C4DC6D /* NavigationButtonHStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C12EB32E3380B900C4DC6D /* NavigationButtonHStack.swift */; };
+		C5C12EB62E3380D100C4DC6D /* NavigationEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C12EB52E3380D100C4DC6D /* NavigationEnums.swift */; };
 		C5F7B69C2E2EB25F0066B59C /* Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F7B69B2E2EB25F0066B59C /* Icon.swift */; };
 		C5F7B69F2E2EB7AB0066B59C /* IconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F7B69E2E2EB7AB0066B59C /* IconView.swift */; };
 		C5F7B6A12E2F6A2A0066B59C /* ButtonSolid.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F7B6A02E2F6A2A0066B59C /* ButtonSolid.swift */; };
@@ -182,6 +185,9 @@
 		C5C12EA92E325A1800C4DC6D /* SolidButtonStyler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolidButtonStyler.swift; sourceTree = "<group>"; };
 		C5C12EAB2E325A3B00C4DC6D /* IconButtonStyler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconButtonStyler.swift; sourceTree = "<group>"; };
 		C5C12EAD2E325A5800C4DC6D /* GlassButtonStyler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassButtonStyler.swift; sourceTree = "<group>"; };
+		C5C12EB02E33684F00C4DC6D /* SnappieNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnappieNavigationBar.swift; sourceTree = "<group>"; };
+		C5C12EB32E3380B900C4DC6D /* NavigationButtonHStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationButtonHStack.swift; sourceTree = "<group>"; };
+		C5C12EB52E3380D100C4DC6D /* NavigationEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationEnums.swift; sourceTree = "<group>"; };
 		C5F7B69B2E2EB25F0066B59C /* Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Icon.swift; sourceTree = "<group>"; };
 		C5F7B69E2E2EB7AB0066B59C /* IconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconView.swift; sourceTree = "<group>"; };
 		C5F7B6A02E2F6A2A0066B59C /* ButtonSolid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonSolid.swift; sourceTree = "<group>"; };
@@ -593,11 +599,21 @@
 			path = Button;
 			sourceTree = "<group>";
 		};
+		C5C12EB22E33809F00C4DC6D /* NavigationBar */ = {
+			isa = PBXGroup;
+			children = (
+				C5C12EB32E3380B900C4DC6D /* NavigationButtonHStack.swift */,
+				C5C12EB52E3380D100C4DC6D /* NavigationEnums.swift */,
+			);
+			path = NavigationBar;
+			sourceTree = "<group>";
+		};
 		C5F7B69D2E2EB78D0066B59C /* Component */ = {
 			isa = PBXGroup;
 			children = (
 				C5F7B69E2E2EB7AB0066B59C /* IconView.swift */,
 				C5C12EA12E2FEE1C00C4DC6D /* SnappieButton.swift */,
+				C5C12EB02E33684F00C4DC6D /* SnappieNavigationBar.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -617,6 +633,7 @@
 				C5FB3ECD2E2E1C1200A4C1BE /* SnappieColor.swift */,
 				C5F7B69B2E2EB25F0066B59C /* Icon.swift */,
 				C5C12EAF2E325CD100C4DC6D /* Button */,
+				C5C12EB22E33809F00C4DC6D /* NavigationBar */,
 			);
 			path = DesignSystem;
 			sourceTree = "<group>";
@@ -772,6 +789,7 @@
 				993A1F572E267E0C0059B70A /* HeightFeedbackView.swift in Sources */,
 				99C93A3D2E2B998600F42541 /* UIImage + Ext.swift in Sources */,
 				993A1F582E267E0C0059B70A /* HeightMeasurementARView.swift in Sources */,
+				C5C12EB62E3380D100C4DC6D /* NavigationEnums.swift in Sources */,
 				993A1F592E267E0C0059B70A /* OverlayManager.swift in Sources */,
 				C5C12EAC2E325A3B00C4DC6D /* IconButtonStyler.swift in Sources */,
 				993A21822E26ABAC0059B70A /* Array + Ext.swift in Sources */,
@@ -794,6 +812,7 @@
 				993A1F642E267E0C0059B70A /* TimerOptions.swift in Sources */,
 				993A1F652E267E0C0059B70A /* CameraPreviewView.swift in Sources */,
 				993A1F662E267E0C0059B70A /* CameraBaseFeatureSelectView.swift in Sources */,
+				C5C12EB12E33684F00C4DC6D /* SnappieNavigationBar.swift in Sources */,
 				C5FB3EBD2E26AA0700A4C1BE /* VideoMerger.swift in Sources */,
 				993A1F672E267E0C0059B70A /* CameraBottomControlView.swift in Sources */,
 				C5FB3EC12E28F11100A4C1BE /* PhotoLibrarySaver.swift in Sources */,
@@ -814,6 +833,7 @@
 				99C7266A2E2F068800E9D0CD /* FirstShootCameraView.swift in Sources */,
 				993A1F6D2E267E0C0059B70A /* ZoomSlider.swift in Sources */,
 				993A1F6E2E267E0C0059B70A /* CameraView.swift in Sources */,
+				C5C12EB42E3380B900C4DC6D /* NavigationButtonHStack.swift in Sources */,
 				C5C12EAA2E325A1800C4DC6D /* SolidButtonStyler.swift in Sources */,
 				993A1F6F2E267E0C0059B70A /* CameraViewModel.swift in Sources */,
 				993A1F702E267E0C0059B70A /* ShootState.swift in Sources */,

--- a/Chalkak/Common/Component/SnappieNavigationBar.swift
+++ b/Chalkak/Common/Component/SnappieNavigationBar.swift
@@ -1,0 +1,91 @@
+//
+//  SnappieNavigationBar.swift
+//  Chalkak
+//
+//  Created by 석민솔 on 7/25/25.
+//
+
+import SwiftUI
+
+/// 기본 네비게이션바 컴포넌트입니다.
+struct SnappieNavigationBar: View {
+    // MARK: input properties
+    /// 네비게이션 타이틀입니다. 제목이 있는 경우 입력해주세요.
+    ///
+    /// 제목을 입력하지 않는 경우 기본값으로 없음 처리됩니다.
+    var navigationTitle: String? = nil
+
+    /// 좌측 버튼의 스타일입니다. 이전 또는 X를 enum타입으로 입력해주세요
+    let leftButtonType: LeftButtonType
+
+    /// 우측 버튼의 스타일입니다. 버튼이 없거나, 있다면 필요한 값들을 입력해주세요
+    let rightButtonType: RightButtonType
+
+    // MARK: body
+    var body: some View {
+        ZStack(alignment: .center) {
+            // 버튼
+            NavigationButtonHStack(
+                leftButtonType: leftButtonType,
+                rightButtonType: rightButtonType
+            )
+
+            // 제목
+            if let navigationTitle {
+                Text(navigationTitle)
+                    .font(SnappieFont.style(.proLabel1))
+                    .foregroundStyle(Color.matcha50)
+                    .frame(maxWidth: .infinity, alignment: .center)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+    }
+}
+
+#Preview {
+    ZStack {
+        SnappieColor.darkHeavy
+
+        VStack(spacing: 20) {
+            // 이전(<) 버튼 & 우측 1개 버튼
+            SnappieNavigationBar(
+                leftButtonType: .backward {
+                    // 뒤로가기 acion
+                },
+                rightButtonType: .oneButton(
+                    .init(
+                        label: "singleButton",
+                        action: {}
+                    )
+                )
+            )
+            .background(
+                // padding을 보여드리기 위한 bcg입니다. 기본적으로 가로 16, 세로 8 패딩이 적용되어 있습니다.
+                Color.white
+            )
+
+            // dismiss(x) 버튼 & 우측 2개 버튼
+            SnappieNavigationBar(
+                leftButtonType: .dismiss {
+                    // dismiss action
+                },
+                rightButtonType: .twoButton(
+                    primary: .init(label: "firstButton") {},
+                    secondary: .init(label: "sceondButton") {}
+                )
+            )
+
+            // dismiss(x) 버튼 & title 있음 & 우측 버튼
+            SnappieNavigationBar(
+                navigationTitle: "title",
+                leftButtonType: .dismiss {
+                    // dismiss action
+                },
+                rightButtonType: .oneButton(
+                    .init(label: "label") {}
+                )
+            )
+        }
+    }
+}

--- a/Chalkak/Common/DesignSystem/NavigationBar/NavigationButtonHStack.swift
+++ b/Chalkak/Common/DesignSystem/NavigationBar/NavigationButtonHStack.swift
@@ -1,0 +1,89 @@
+//
+//  NavigationButtonHStack.swift
+//  Chalkak
+//
+//  Created by 석민솔 on 7/25/25.
+//
+
+import SwiftUI
+
+extension SnappieNavigationBar {
+
+    /// 네비게이션용 좌우측 버튼(들)이 분기처리되어있는 HStack입니다.
+    struct NavigationButtonHStack: View {
+        // input properties
+        let leftButtonType: LeftButtonType
+        let rightButtonType: RightButtonType
+
+        // computed properties
+        var primaryRightButton: ItemsForButton? {
+            switch rightButtonType {
+            case .none:
+                nil
+            case .oneButton(let button):
+                button
+            case .twoButton(let primaryButton, _):
+                primaryButton
+            }
+        }
+
+        var secondaryRightButton: ItemsForButton? {
+            switch rightButtonType {
+            case .twoButton(_, let secondaryButton):
+                secondaryButton
+            default: nil
+            }
+        }
+
+        // body
+        var body: some View {
+            HStack {
+                // left button
+                switch leftButtonType {
+                case .backward(let action):
+                    SnappieButton(
+                        .iconBackground(
+                            icon: .chevronBackward,
+                            size: .medium
+                        ),
+                        action: action
+                    )
+
+                case .dismiss(let action):
+                    SnappieButton(
+                        .iconBackground(
+                            icon: .dismiss,
+                            size: .medium
+                        ),
+                        action: action
+                    )
+                }
+
+                Spacer()
+
+                // (right button(s))
+                if let secondaryRightButton {
+                    SnappieButton(
+                        .solidSecondary(
+                            contentType: .text(secondaryRightButton.label),
+                            size: .medium,
+                            isOutlined: true
+                        ),
+                        action: secondaryRightButton.action
+                    )
+                }
+
+                if let primaryRightButton {
+                    SnappieButton(
+                        .solidPrimary(
+                            title: primaryRightButton.label,
+                            size: .medium
+                        ),
+                        action: primaryRightButton.action
+                    )
+                }
+            }
+        }
+    }
+
+}

--- a/Chalkak/Common/DesignSystem/NavigationBar/NavigationEnums.swift
+++ b/Chalkak/Common/DesignSystem/NavigationBar/NavigationEnums.swift
@@ -1,0 +1,32 @@
+//
+//  NavigationEnums.swift
+//  Chalkak
+//
+//  Created by 석민솔 on 7/25/25.
+//
+
+import Foundation
+
+// 네비게이션용 커스텀 타입들
+extension SnappieNavigationBar {
+    /// 네비게이션바 왼쪽 버튼용 enum
+    enum LeftButtonType {
+        /// `<` 버튼  with action
+        case backward(() -> Void)
+        ///  `x`버튼  with action
+        case dismiss(() -> Void)
+    }
+
+    /// 네비게이션바 오른쪽 버튼용 enum
+    enum RightButtonType {
+        case none
+        case oneButton(ItemsForButton)
+        case twoButton(primary: ItemsForButton, secondary: ItemsForButton)
+    }
+
+    /// 버튼을 위해 필요한 정보들
+    struct ItemsForButton {
+        let label: String
+        let action: () -> Void
+    }
+}


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #93 

## ✨ PR Content
> 작업 내용 설명을 적어주세요.

- 좌측/우측 버튼 및 타이틀 설정이 가능한 네비게이션 바 컴포넌트 UI 
- 관련 enum 및 모델 추가
- **SnappieNavigationBar.swift**가 메인 코드입니다!

## 📸 Screenshot
> 작업 화면의 스크린샷을 추가해주세요.

<img width="668" height="309" alt="스크린샷 2025-07-25 오후 8 23 09" src="https://github.com/user-attachments/assets/106bfa1f-482d-458a-91eb-255a8cdb6035" />

흰색은 영역을 위해 background를 의도적으로 추가한 케이스입니다. 두번째, 세번째 줄처럼 배경색 없이 투명한 네비게이션바라고 생각해주심 됩니다

## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요

- 네비게이션 바 안에서만 사용하는 enum, struct여서 extension으로 다른 파일로 분리해서 구현했습니다.
- 다른 뷰 컴포넌트도 공통으로 horizontal padding을 적용할 만한 화면이 잘 안 보여서 기본적으로 가로 패딩이 있는 형태로 구현했습니다! 불편하시면 얼마든지 수정 가능합니다.
- 예시코드(SnappieNavigationBar.swift의 #Preview에서도 확인 가능합니다)
```swift
// 이전(<) 버튼 & 우측 1개 버튼
SnappieNavigationBar(
    leftButtonType: .backward {
        // 뒤로가기 acion
    },
    rightButtonType: .oneButton(
        .init(
            label: "singleButton",
            action: {}
        )
    )
)

// dismiss(x) 버튼 & 우측 2개 버튼
SnappieNavigationBar(
    leftButtonType: .dismiss {
        // dismiss action
    },
    rightButtonType: .twoButton(
        primary: .init(label: "firstButton") {},
        secondary: .init(label: "sceondButton") {}
    )
)

// dismiss(x) 버튼 & title 있음 & 우측 버튼
SnappieNavigationBar(
    navigationTitle: "title",
    leftButtonType: .dismiss {
        // dismiss action
    },
    rightButtonType: .oneButton(
        .init(label: "label") {}
    )
)
```

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
