### PR TITLE
🍱 [Asset] label 폰트 weight 변경

### DIFF
--- a/Chalkak/Common/DesignSystem/SnappieFont.swift
+++ b/Chalkak/Common/DesignSystem/SnappieFont.swift
@@ -115,9 +115,9 @@ enum SnappieFont {
             case .proBody1:
                     .regular
             case .proLabel1:
-                    .medium
+                    .semibold
             case .proLabel2:
-                    .medium
+                    .semibold
             case .proLabel3:
                     .semibold
             case .proCaption1:


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #110 

## ✨ PR Content
> 작업 내용 설명을 적어주세요.

sf pro 폰트의 label1, label2 스타일 두께를 디자인에 맞춰서 semibold로 반영했습니다.


## 📸 Screenshot
> 작업 화면의 스크린샷을 추가해주세요.

before & after
<img width="400" alt="image" src="https://github.com/user-attachments/assets/c4d9e69d-84b0-4641-8516-4a34e1fdd89b" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/b2811900-039c-48c3-81f2-b9c572e76d4d" />

## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요

- 특이 사항 1
- 특이 사항 2

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
