### PR TITLE
Style/#115/boundingbox feedback hifi

### DIFF
--- a/Chalkak/Presentation/Camera/CameraView.swift
+++ b/Chalkak/Presentation/Camera/CameraView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct CameraView: View {
     let guide: Guide?
+    let isAligned: Bool
 
     @ObservedObject var viewModel: CameraViewModel
     @EnvironmentObject private var coordinator: Coordinator
@@ -18,7 +19,11 @@ struct CameraView: View {
 
     var body: some View {
         ZStack {
-            SnappieColor.darkHeavy.edgesIgnoringSafeArea(.all)
+            if isAligned {
+                SnappieColor.primaryStrong.edgesIgnoringSafeArea(.all)
+            } else {
+                SnappieColor.darkHeavy.edgesIgnoringSafeArea(.all)
+            }
 
             CameraPreviewView(
                 session: viewModel.session,

--- a/Chalkak/Presentation/Guide/Distance/SubViews/FirstShootCameraView.swift
+++ b/Chalkak/Presentation/Guide/Distance/SubViews/FirstShootCameraView.swift
@@ -13,7 +13,7 @@ struct FirstShootCameraView: View {
 
     var body: some View {
         ZStack {
-            CameraView(guide: nil, viewModel: cameraViewModel)
+            CameraView(guide: nil, isAligned: false, viewModel: cameraViewModel)
         }
         .onAppear() {
             viewModel.deleteUserDefault()

--- a/Chalkak/Presentation/Guide/Distance/SubViews/GuideCameraView.swift
+++ b/Chalkak/Presentation/Guide/Distance/SubViews/GuideCameraView.swift
@@ -28,13 +28,7 @@ struct GuideCameraView: View {
     
     var body: some View {
         ZStack {
-            if viewModel.isAligned {
-                Color.blue
-                    .ignoresSafeArea()
-                    .transition(.opacity)
-            }
-
-            CameraView(guide: guide, viewModel: cameraViewModel)
+            CameraView(guide: guide, isAligned: viewModel.isAligned, viewModel: cameraViewModel)
                 .onAppear {
                     cameraViewModel.setBoundingBoxUpdateHandler { bboxes in
                         viewModel.liveBoundingBoxes = bboxes

--- a/Chalkak/Presentation/Guide/Distance/SubViews/GuideCameraView.swift
+++ b/Chalkak/Presentation/Guide/Distance/SubViews/GuideCameraView.swift
@@ -41,6 +41,9 @@ struct GuideCameraView: View {
                     .aspectRatio(contentMode: .fit)
                     .allowsHitTesting(false)
                     .scaleEffect(x: cameraViewModel.isUsingFrontCamera ? -1 : 1, y: 1)
+                    .padding(.top, 12)
+                    .padding(.horizontal, 16)
+                    .frame(maxHeight: .infinity, alignment: .top)
             } else {
                 Text("윤곽선 이미지 없음")
                     .foregroundColor(.gray)


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #115

## ✨ PR Content
> 작업 내용 설명을 적어주세요.

Bounding Box 이용한 거리와 위치 피드백에 Hifi를 반영했습니다.

## 📸 Screenshot
> 작업 화면의 스크린샷을 추가해주세요.


https://github.com/user-attachments/assets/073f91b6-42f8-472e-a956-932073741766


## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요

- 실루엣 오버레이 가이드 위치 수정
CameraView에 Hifi를 입히는 과정에서 뷰의 크기/위치가 조절되었는데,
그 위에 동일한 크기로 표시되는 실루엣 오버레이에는 변화가 없어서
실제로 빌드해 테스트해볼 경우 실루엣 오버레이가 커지고 위치가 달라지는 등의 문제가 있어 개선했습니다.


## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
