### PR TITLE
✨ [Feat] 프로젝트 편집 기능 구현

### DIFF
--- a/Chalkak.xcodeproj/project.pbxproj
+++ b/Chalkak.xcodeproj/project.pbxproj
@@ -7,6 +7,19 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		992EE7C22E32ACBA0079AFBF /* ProjectEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992EE7C12E32ACB50079AFBF /* ProjectEditView.swift */; };
+		992EE7C42E32ACFD0079AFBF /* ProjectEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992EE7C32E32ACF80079AFBF /* ProjectEditViewModel.swift */; };
+		992EE7C62E32AD900079AFBF /* TrimmingLineSliderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992EE7C52E32AD7B0079AFBF /* TrimmingLineSliderView.swift */; };
+		992EE7C82E32AE200079AFBF /* PlayButtonControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992EE7C72E32AE190079AFBF /* PlayButtonControlView.swift */; };
+		992EE7CC2E32AEE00079AFBF /* EditableClip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992EE7CB2E32AED70079AFBF /* EditableClip.swift */; };
+		992EE7CE2E32AF030079AFBF /* ClipTrimmingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992EE7CD2E32AEF80079AFBF /* ClipTrimmingView.swift */; };
+		992EE80B2E36BC9F0079AFBF /* AVMutableComposition + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992EE80A2E36BC980079AFBF /* AVMutableComposition + Ext.swift */; };
+		992EE80D2E36C8C90079AFBF /* PlayTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992EE80C2E36C8C60079AFBF /* PlayTimeView.swift */; };
+		992EE80F2E36CE690079AFBF /* ProjectThumbnailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992EE80E2E36CE570079AFBF /* ProjectThumbnailsView.swift */; };
+		992EE8112E36CECD0079AFBF /* ProjectTrimmingLineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992EE8102E36CEBE0079AFBF /* ProjectTrimmingLineView.swift */; };
+		992EE8132E36CF070079AFBF /* ProjectTrimmingHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992EE8122E36CF020079AFBF /* ProjectTrimmingHandle.swift */; };
+		992EE8152E36CF660079AFBF /* ProjectTimeBoardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992EE8142E36CF600079AFBF /* ProjectTimeBoardView.swift */; };
+		992EE8172E36CFE70079AFBF /* ProjectTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992EE8162E36CFB00079AFBF /* ProjectTimelineView.swift */; };
 		993A1F502E267E0C0059B70A /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 993A1F4A2E267E0C0059B70A /* Preview Assets.xcassets */; };
 		993A1F512E267E0C0059B70A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 993A1F4C2E267E0C0059B70A /* Assets.xcassets */; };
 		993A1F522E267E0C0059B70A /* sample-video.mov in Resources */ = {isa = PBXBuildFile; fileRef = 993A1F4D2E267E0C0059B70A /* sample-video.mov */; };
@@ -65,6 +78,7 @@
 		99C93A0E2E27BB0700F42541 /* Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C93A0D2E27BB0300F42541 /* Path.swift */; };
 		99C93A3B2E2B740300F42541 /* CameraSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C93A3A2E2B73FD00F42541 /* CameraSetting.swift */; };
 		99C93A3D2E2B998600F42541 /* UIImage + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C93A3C2E2B998100F42541 /* UIImage + Ext.swift */; };
+		B6AB62AE2E2E8DBE00207590 /* TorchMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AB62AD2E2E8B7700207590 /* TorchMode.swift */; };
 		C5C12EA02E2FED5A00C4DC6D /* ButtonStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C12E9F2E2FED5500C4DC6D /* ButtonStyler.swift */; };
 		C5C12EA22E2FEE1C00C4DC6D /* SnappieButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C12EA12E2FEE1C00C4DC6D /* SnappieButton.swift */; };
 		C5C12EA42E31CDFB00C4DC6D /* SnappieButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C12EA32E31CDFB00C4DC6D /* SnappieButtonStyle.swift */; };
@@ -77,7 +91,6 @@
 		C5F7B69F2E2EB7AB0066B59C /* IconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F7B69E2E2EB7AB0066B59C /* IconView.swift */; };
 		C5F7B6A12E2F6A2A0066B59C /* ButtonSolid.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F7B6A02E2F6A2A0066B59C /* ButtonSolid.swift */; };
 		C5F7B6A32E2F6AD20066B59C /* ButtonStyleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F7B6A22E2F6AD20066B59C /* ButtonStyleType.swift */; };
-		B6AB62AE2E2E8DBE00207590 /* TorchMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AB62AD2E2E8B7700207590 /* TorchMode.swift */; };
 		C5FB3EBD2E26AA0700A4C1BE /* VideoMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5FB3EBC2E26AA0700A4C1BE /* VideoMerger.swift */; };
 		C5FB3EBF2E277CAA00A4C1BE /* VideoLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5FB3EBE2E277CAA00A4C1BE /* VideoLoader.swift */; };
 		C5FB3EC12E28F11100A4C1BE /* PhotoLibrarySaver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5FB3EC02E28F11100A4C1BE /* PhotoLibrarySaver.swift */; };
@@ -107,6 +120,19 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		992EE7C12E32ACB50079AFBF /* ProjectEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectEditView.swift; sourceTree = "<group>"; };
+		992EE7C32E32ACF80079AFBF /* ProjectEditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectEditViewModel.swift; sourceTree = "<group>"; };
+		992EE7C52E32AD7B0079AFBF /* TrimmingLineSliderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimmingLineSliderView.swift; sourceTree = "<group>"; };
+		992EE7C72E32AE190079AFBF /* PlayButtonControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayButtonControlView.swift; sourceTree = "<group>"; };
+		992EE7CB2E32AED70079AFBF /* EditableClip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableClip.swift; sourceTree = "<group>"; };
+		992EE7CD2E32AEF80079AFBF /* ClipTrimmingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipTrimmingView.swift; sourceTree = "<group>"; };
+		992EE80A2E36BC980079AFBF /* AVMutableComposition + Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVMutableComposition + Ext.swift"; sourceTree = "<group>"; };
+		992EE80C2E36C8C60079AFBF /* PlayTimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayTimeView.swift; sourceTree = "<group>"; };
+		992EE80E2E36CE570079AFBF /* ProjectThumbnailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectThumbnailsView.swift; sourceTree = "<group>"; };
+		992EE8102E36CEBE0079AFBF /* ProjectTrimmingLineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectTrimmingLineView.swift; sourceTree = "<group>"; };
+		992EE8122E36CF020079AFBF /* ProjectTrimmingHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectTrimmingHandle.swift; sourceTree = "<group>"; };
+		992EE8142E36CF600079AFBF /* ProjectTimeBoardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectTimeBoardView.swift; sourceTree = "<group>"; };
+		992EE8162E36CFB00079AFBF /* ProjectTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectTimelineView.swift; sourceTree = "<group>"; };
 		993A1CC62E2049D50059B70A /* Chalkak.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Chalkak.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		993A1CD62E2049D60059B70A /* ChalkakTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ChalkakTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		993A1CE02E2049D60059B70A /* ChalkakUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ChalkakUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -169,6 +195,7 @@
 		99C93A3A2E2B73FD00F42541 /* CameraSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraSetting.swift; sourceTree = "<group>"; };
 		99C93A3C2E2B998100F42541 /* UIImage + Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage + Ext.swift"; sourceTree = "<group>"; };
 		B655A8672E26A4EE0060E2C0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		B6AB62AD2E2E8B7700207590 /* TorchMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorchMode.swift; sourceTree = "<group>"; };
 		C5C12E9F2E2FED5500C4DC6D /* ButtonStyler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonStyler.swift; sourceTree = "<group>"; };
 		C5C12EA12E2FEE1C00C4DC6D /* SnappieButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnappieButton.swift; sourceTree = "<group>"; };
 		C5C12EA32E31CDFB00C4DC6D /* SnappieButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnappieButtonStyle.swift; sourceTree = "<group>"; };
@@ -181,7 +208,6 @@
 		C5F7B69E2E2EB7AB0066B59C /* IconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconView.swift; sourceTree = "<group>"; };
 		C5F7B6A02E2F6A2A0066B59C /* ButtonSolid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonSolid.swift; sourceTree = "<group>"; };
 		C5F7B6A22E2F6AD20066B59C /* ButtonStyleType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonStyleType.swift; sourceTree = "<group>"; };
-		B6AB62AD2E2E8B7700207590 /* TorchMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorchMode.swift; sourceTree = "<group>"; };
 		C5FB3EBC2E26AA0700A4C1BE /* VideoMerger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoMerger.swift; sourceTree = "<group>"; };
 		C5FB3EBE2E277CAA00A4C1BE /* VideoLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoLoader.swift; sourceTree = "<group>"; };
 		C5FB3EC02E28F11100A4C1BE /* PhotoLibrarySaver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoLibrarySaver.swift; sourceTree = "<group>"; };
@@ -216,6 +242,41 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		992EE7C02E32AC820079AFBF /* ProjectEdit */ = {
+			isa = PBXGroup;
+			children = (
+				992EE7CA2E32AECF0079AFBF /* Model */,
+				992EE7C92E32AEBE0079AFBF /* SubViews */,
+				992EE7C32E32ACF80079AFBF /* ProjectEditViewModel.swift */,
+				992EE7C12E32ACB50079AFBF /* ProjectEditView.swift */,
+			);
+			path = ProjectEdit;
+			sourceTree = "<group>";
+		};
+		992EE7C92E32AEBE0079AFBF /* SubViews */ = {
+			isa = PBXGroup;
+			children = (
+				992EE8162E36CFB00079AFBF /* ProjectTimelineView.swift */,
+				992EE8142E36CF600079AFBF /* ProjectTimeBoardView.swift */,
+				992EE8122E36CF020079AFBF /* ProjectTrimmingHandle.swift */,
+				992EE8102E36CEBE0079AFBF /* ProjectTrimmingLineView.swift */,
+				992EE80E2E36CE570079AFBF /* ProjectThumbnailsView.swift */,
+				992EE80C2E36C8C60079AFBF /* PlayTimeView.swift */,
+				992EE7CD2E32AEF80079AFBF /* ClipTrimmingView.swift */,
+				992EE7C52E32AD7B0079AFBF /* TrimmingLineSliderView.swift */,
+				992EE7C72E32AE190079AFBF /* PlayButtonControlView.swift */,
+			);
+			path = SubViews;
+			sourceTree = "<group>";
+		};
+		992EE7CA2E32AECF0079AFBF /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				992EE7CB2E32AED70079AFBF /* EditableClip.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 		993A1CBD2E2049D50059B70A = {
 			isa = PBXGroup;
 			children = (
@@ -436,6 +497,7 @@
 				993A1F392E267E0C0059B70A /* Camera */,
 				993A1F452E267E0C0059B70A /* ClipEdit */,
 				993A1F482E267E0C0059B70A /* ProjectPreview */,
+				992EE7C02E32AC820079AFBF /* ProjectEdit */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -524,6 +586,7 @@
 		993A21802E26AB9C0059B70A /* Extension */ = {
 			isa = PBXGroup;
 			children = (
+				992EE80A2E36BC980079AFBF /* AVMutableComposition + Ext.swift */,
 				99C93A3C2E2B998100F42541 /* UIImage + Ext.swift */,
 				993A21812E26ABA70059B70A /* Array + Ext.swift */,
 				C5FB3ED02E2E8EAF00A4C1BE /* Text + Ext.swift */,
@@ -760,6 +823,8 @@
 				C5FB3ECE2E2E1C1200A4C1BE /* SnappieColor.swift in Sources */,
 				993A1F532E267E0C0059B70A /* ChalkakApp.swift in Sources */,
 				993A1F542E267E0C0059B70A /* CameraManager.swift in Sources */,
+				992EE7CC2E32AEE00079AFBF /* EditableClip.swift in Sources */,
+				992EE80B2E36BC9F0079AFBF /* AVMutableComposition + Ext.swift in Sources */,
 				C5C12EA42E31CDFB00C4DC6D /* SnappieButtonStyle.swift in Sources */,
 				993A1F552E267E0C0059B70A /* BoundingBoxManager.swift in Sources */,
 				993A1F562E267E0C0059B70A /* CameraHeightManager.swift in Sources */,
@@ -768,7 +833,9 @@
 				993A1F582E267E0C0059B70A /* HeightMeasurementARView.swift in Sources */,
 				993A1F592E267E0C0059B70A /* OverlayManager.swift in Sources */,
 				C5C12EAC2E325A3B00C4DC6D /* IconButtonStyler.swift in Sources */,
+				992EE80D2E36C8C90079AFBF /* PlayTimeView.swift in Sources */,
 				993A21822E26ABAC0059B70A /* Array + Ext.swift in Sources */,
+				992EE7C62E32AD900079AFBF /* TrimmingLineSliderView.swift in Sources */,
 				993A1F5A2E267E0C0059B70A /* CameraTiltManager.swift in Sources */,
 				993A217B2E26A07C0059B70A /* BoundingBoxView.swift in Sources */,
 				C5FB3EC82E2E110500A4C1BE /* SnappieFont.swift in Sources */,
@@ -786,6 +853,7 @@
 				993A1F622E267E0C0059B70A /* Tilt.swift in Sources */,
 				993A1F632E267E0C0059B70A /* SwiftDataManager.swift in Sources */,
 				993A1F642E267E0C0059B70A /* TimerOptions.swift in Sources */,
+				992EE8172E36CFE70079AFBF /* ProjectTimelineView.swift in Sources */,
 				993A1F652E267E0C0059B70A /* CameraPreviewView.swift in Sources */,
 				993A1F662E267E0C0059B70A /* CameraBaseFeatureSelectView.swift in Sources */,
 				C5FB3EBD2E26AA0700A4C1BE /* VideoMerger.swift in Sources */,
@@ -798,6 +866,7 @@
 				C5F7B69F2E2EB7AB0066B59C /* IconView.swift in Sources */,
 				993A1F682E267E0C0059B70A /* CameraDefaultTopControlView.swift in Sources */,
 				999992472E2D869C00D56BD1 /* BoundingBoxInfo.swift in Sources */,
+				992EE7C82E32AE200079AFBF /* PlayButtonControlView.swift in Sources */,
 				993A1F692E267E0C0059B70A /* CameraRecordView.swift in Sources */,
 				993A1F6A2E267E0C0059B70A /* CameraTopControlView.swift in Sources */,
 				C5FB3EBF2E277CAA00A4C1BE /* VideoLoader.swift in Sources */,
@@ -808,21 +877,28 @@
 				99C7266A2E2F068800E9D0CD /* FirstShootCameraView.swift in Sources */,
 				993A1F6D2E267E0C0059B70A /* ZoomSlider.swift in Sources */,
 				993A1F6E2E267E0C0059B70A /* CameraView.swift in Sources */,
+				992EE7CE2E32AF030079AFBF /* ClipTrimmingView.swift in Sources */,
 				C5C12EAA2E325A1800C4DC6D /* SolidButtonStyler.swift in Sources */,
 				993A1F6F2E267E0C0059B70A /* CameraViewModel.swift in Sources */,
+				992EE8152E36CF660079AFBF /* ProjectTimeBoardView.swift in Sources */,
 				993A1F702E267E0C0059B70A /* ShootState.swift in Sources */,
 				993A1F712E267E0C0059B70A /* OverlayDisplayView.swift in Sources */,
 				993A1F722E267E0C0059B70A /* OverlayView.swift in Sources */,
+				992EE8132E36CF070079AFBF /* ProjectTrimmingHandle.swift in Sources */,
 				993A1F732E267E0C0059B70A /* OverlayViewModel.swift in Sources */,
+				992EE80F2E36CE690079AFBF /* ProjectThumbnailsView.swift in Sources */,
 				993A217D2E26A0870059B70A /* BoundingBoxViewModel.swift in Sources */,
 				993A1F742E267E0C0059B70A /* TrimmingControlView.swift in Sources */,
 				993A1F752E267E0C0059B70A /* TrimmingLineView.swift in Sources */,
 				993A1F762E267E0C0059B70A /* TrimmingTimeDisplay.swift in Sources */,
+				992EE7C42E32ACFD0079AFBF /* ProjectEditViewModel.swift in Sources */,
 				993A1F772E267E0C0059B70A /* VideoPreviewView.swift in Sources */,
 				993A1F782E267E0C0059B70A /* ClipEditView.swift in Sources */,
 				993A1F792E267E0C0059B70A /* ClipEditViewModel.swift in Sources */,
+				992EE8112E36CECD0079AFBF /* ProjectTrimmingLineView.swift in Sources */,
 				C5FB3ED12E2E8EAF00A4C1BE /* Text + Ext.swift in Sources */,
 				993A1F7A2E267E0C0059B70A /* ProjectPreviewView.swift in Sources */,
+				992EE7C22E32ACBA0079AFBF /* ProjectEditView.swift in Sources */,
 				993A1F7B2E267E0C0059B70A /* ProjectPreviewViewModel.swift in Sources */,
 				C5F7B6A12E2F6A2A0066B59C /* ButtonSolid.swift in Sources */,
 				99C93A3B2E2B740300F42541 /* CameraSetting.swift in Sources */,
@@ -991,7 +1067,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Chalkak/Preview Content\"";
-				DEVELOPMENT_TEAM = SM37WHUJB5;
+				DEVELOPMENT_TEAM = F83F8K6223;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Chalkak/Info.plist;
@@ -1025,7 +1101,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Chalkak/Preview Content\"";
-				DEVELOPMENT_TEAM = SM37WHUJB5;
+				DEVELOPMENT_TEAM = F83F8K6223;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Chalkak/Info.plist;

--- a/Chalkak/App/ChalkakApp.swift
+++ b/Chalkak/App/ChalkakApp.swift
@@ -36,10 +36,10 @@ struct ChalkakApp: App {
                                 cameraSetting: cameraSetting,
                                 timeStampedTiltList: timeStampedTiltList
                             )
-
+                            
                         case .overlay(let clip):
                             OverlayView(clip: clip)
-
+                            
                         case .boundingBox(let guide):
                             BoundingBoxView(guide: guide)
                                 .toolbar(.hidden, for: .navigationBar)
@@ -47,6 +47,9 @@ struct ChalkakApp: App {
                             
                         case .projectPreview(finalVideoURL: let finalVideoURL):
                             ProjectPreviewView(finalVideoURL: finalVideoURL)
+                        
+                        case .projectEdit:
+                            ProjectEditView()
                         }
                     }
             }

--- a/Chalkak/Common/Extension/AVMutableComposition + Ext.swift
+++ b/Chalkak/Common/Extension/AVMutableComposition + Ext.swift
@@ -1,0 +1,68 @@
+//
+//  AVMutableComposition.swift
+//  Chalkak
+//
+//  Created by 배현진 on 7/28/25.
+//
+
+import AVFoundation
+
+extension AVMutableComposition {
+    /// editableClips와 trimming 범위를 사용해서,
+    /// 각 세그먼트마다 원본 preferredTransform을 적용한 VideoComposition 생성
+    func makePreviewVideoComposition(
+        using editableClips: [EditableClip]
+    ) -> AVMutableVideoComposition {
+        // 합성된 트랙
+        guard let compTrack = tracks(withMediaType: .video).first else {
+            fatalError("Video track 없음")
+        }
+        
+        // VideoComposition 틀 설정
+        let videoComp = AVMutableVideoComposition()
+        videoComp.frameDuration = CMTime(value: 1, timescale: 60)
+        
+        // 각 클립별 Instruction 생성
+        var cursor = CMTime.zero
+        var instructions: [AVMutableVideoCompositionInstruction] = []
+        
+        for clip in editableClips {
+            // 원본 에셋 로드
+            let asset = AVAsset(url: clip.url)
+            guard let assetTrack = asset.tracks(withMediaType: .video).first else {
+                continue
+            }
+            
+            // 이 클립의 표시 구간
+            let duration = CMTime(seconds: clip.trimmedDuration, preferredTimescale: 600)
+            let timeRange = CMTimeRange(start: cursor, duration: duration)
+            
+            // Instruction & LayerInstruction
+            let instr = AVMutableVideoCompositionInstruction()
+            instr.timeRange = timeRange
+            
+            let layerInstr = AVMutableVideoCompositionLayerInstruction(assetTrack: compTrack)
+            // 클립마다 다른 preferredTransform 적용
+            let t = assetTrack.preferredTransform
+            layerInstr.setTransform(t, at: cursor)
+            
+            instr.layerInstructions = [layerInstr]
+            instructions.append(instr)
+            
+            // 다음 클립 시작 시점으로 이동
+            cursor = cursor + duration
+        }
+        
+        // renderSize 계산 (첫 클립 기준으로)
+        if let firstClip = editableClips.first,
+           let firstAsset = AVAsset(url: firstClip.url).tracks(withMediaType: .video).first
+        {
+            let t = firstAsset.preferredTransform
+            let size = firstAsset.naturalSize.applying(t)
+            videoComp.renderSize = CGSize(width: abs(size.width), height: abs(size.height))
+        }
+        
+        videoComp.instructions = instructions
+        return videoComp
+    }
+}

--- a/Chalkak/Common/Util/Enum/Path.swift
+++ b/Chalkak/Common/Util/Enum/Path.swift
@@ -12,4 +12,5 @@ enum Path: Hashable {
     case overlay(clip: Clip)
     case boundingBox(guide: Guide)
     case projectPreview(finalVideoURL: URL)
+    case projectEdit
 }

--- a/Chalkak/Common/Util/Enum/Path.swift
+++ b/Chalkak/Common/Util/Enum/Path.swift
@@ -10,7 +10,7 @@ import Foundation
 enum Path: Hashable {
     case clipEdit(clipURL: URL, guide: Guide?, cameraSetting: CameraSetting, TimeStampedTiltList: [TimeStampedTilt])
     case overlay(clip: Clip)
-    case boundingBox(guide: Guide)
+    case boundingBox(guide: Guide?)
     case projectPreview(finalVideoURL: URL)
     case projectEdit
 }

--- a/Chalkak/Data/Model/Clip.swift
+++ b/Chalkak/Data/Model/Clip.swift
@@ -17,6 +17,9 @@ class Clip {
     /// 영상의 바이너리 데이터.
     var videoURL: URL
     
+    /// 원본 영상의 총 길이 (초 단위). 클립 생성 시 한 번만 계산하여 저장됩니다.
+    var originalDuration: Double
+    
     /// 트리밍하여 사용할 영상 구간의 시작 시점. (초 단위)
     var startPoint: Double
     
@@ -32,6 +35,11 @@ class Clip {
     /// 시간별로 기록된 카메라 높이 정보.
     var heightList: [TimeStampedHeight]
     
+    /// 트리밍된 시간을 계산한 정보.
+    var currentTrimmedDuration: Double {
+        return endPoint - startPoint
+    }
+    
     /// 새로운 Clip 인스턴스를 초기화합니다.
     /// - Parameters:
     ///   - id: 클립의 고유 ID (기본값은 UUID).
@@ -44,6 +52,7 @@ class Clip {
     init(
         id: String = UUID().uuidString,
         videoURL: URL,
+        originalDuration: Double,
         startPoint: Double = 0,
         endPoint: Double,
         createdAt: Date = .now,
@@ -52,6 +61,7 @@ class Clip {
     ) {
         self.id = id
         self.videoURL = videoURL
+        self.originalDuration = originalDuration
         self.startPoint = startPoint
         self.endPoint = endPoint
         self.createdAt = createdAt

--- a/Chalkak/Data/SwiftDataManager.swift
+++ b/Chalkak/Data/SwiftDataManager.swift
@@ -167,6 +167,18 @@ class SwiftDataManager {
         return guide
     }
 
+    /// `Guide` 저장하고 Project에 연결
+    func saveGuideToProject(projectID: String, guide: Guide) {
+        guard let project = fetchProject(byID: projectID) else {
+            print("해당 ID(\(projectID))의 Project를 찾을 수 없습니다.")
+            return
+        }
+        
+        project.guide = guide
+        context.insert(guide) // guide도 context에 삽입
+        saveContext()
+    }
+    
     /// `Guide` 가져오기
     func fetchGuide(forClipID clipID: String) -> Guide? {
         let predicate = #Predicate<Guide> { $0.clipID == clipID }

--- a/Chalkak/Data/SwiftDataManager.swift
+++ b/Chalkak/Data/SwiftDataManager.swift
@@ -109,6 +109,7 @@ class SwiftDataManager {
     func createClip(
         id: String,
         videoURL: URL,
+        originalDuration: Double,
         startPoint: Double = 0,
         endPoint: Double,
         tiltList: [TimeStampedTilt] = [],
@@ -117,6 +118,7 @@ class SwiftDataManager {
         let clip = Clip(
             id: id,
             videoURL: videoURL,
+            originalDuration: originalDuration,
             startPoint: startPoint,
             endPoint: endPoint,
             tiltList: tiltList,

--- a/Chalkak/Presentation/Camera/SubViews/CameraRecordView.swift
+++ b/Chalkak/Presentation/Camera/SubViews/CameraRecordView.swift
@@ -9,11 +9,20 @@ import SwiftUI
 
 struct CameraRecordView: View {
     @ObservedObject var viewModel: CameraViewModel
+    @EnvironmentObject private var coordinator: Coordinator
     
     var body: some View {
         HStack(spacing: 0) {
-            Color.clear
-                .frame(width: 54, height: 54)
+            Button(action: {
+                coordinator.push(.projectEdit)
+            }) {
+                ZStack {
+                    // TODO: - 이미지 표시 위한 분기 처리 필요
+                    Color.gray
+                        .frame(width: 70, height: 70)
+                }
+                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            }
             
             Spacer()
             

--- a/Chalkak/Presentation/ClipEdit/ClipEditViewModel.swift
+++ b/Chalkak/Presentation/ClipEdit/ClipEditViewModel.swift
@@ -291,6 +291,7 @@ final class ClipEditViewModel: ObservableObject {
         return Clip(
             id: clipID,
             videoURL: clipURL,
+            originalDuration: duration,
             startPoint: startPoint,
             endPoint: endPoint,
             tiltList: timeStampedTiltList,

--- a/Chalkak/Presentation/Guide/Overlay/OverlayViewModel.swift
+++ b/Chalkak/Presentation/Guide/Overlay/OverlayViewModel.swift
@@ -118,8 +118,9 @@ final class OverlayViewModel: ObservableObject {
             cameraHeight: 1.0
         )
         
-        SwiftDataManager.shared.saveContext()
-        
+        if let projectID = UserDefaults.standard.string(forKey: "currentProjectID") {
+            SwiftDataManager.shared.saveGuideToProject(projectID: projectID, guide: guide)
+        }
         return guide
     }
     

--- a/Chalkak/Presentation/ProjectEdit/Model/EditableClip.swift
+++ b/Chalkak/Presentation/ProjectEdit/Model/EditableClip.swift
@@ -7,33 +7,20 @@
 
 import Foundation
 
-struct EditableClip: Identifiable, Equatable {
+struct EditableClip: Identifiable {
     let id: String
     let url: URL
+    let originalDuration: Double
+    
+    // 트리밍 범위
     var startPoint: Double
     var endPoint: Double
-    let originalDuration: Double
-    let createdAt: Date
-
+    
+    // 트리밍 모드 활성화 플래그
     var isTrimming: Bool = false
-
-    var duration: Double {
-        endPoint - startPoint
-    }
-
-    /// 타임라인 상에서의 위치 계산을 위한 프로퍼티 (총 영상 내 상대 위치 계산용)
-    var timelineRange: ClosedRange<Double> {
-        startPoint...endPoint
-    }
-}
-
-extension EditableClip {
-    init(from clip: Clip) {
-        self.id = clip.id
-        self.url = clip.videoURL
-        self.startPoint = clip.startPoint
-        self.endPoint = clip.endPoint
-        self.originalDuration = clip.endPoint
-        self.createdAt = clip.createdAt
+    
+    // 계산 프로퍼티: 실제 플레이 타임
+    var trimmedDuration: Double {
+        max(0, endPoint - startPoint)
     }
 }

--- a/Chalkak/Presentation/ProjectEdit/Model/EditableClip.swift
+++ b/Chalkak/Presentation/ProjectEdit/Model/EditableClip.swift
@@ -6,20 +6,24 @@
 //
 
 import Foundation
+import UIKit
 
 struct EditableClip: Identifiable {
     let id: String
     let url: URL
     let originalDuration: Double
-    
+
     // 트리밍 범위
     var startPoint: Double
     var endPoint: Double
-    
+
     // 트리밍 모드 활성화 플래그
     var isTrimming: Bool = false
-    
-    // 계산 프로퍼티: 실제 플레이 타임
+
+    // 미리 생성된 썸네일 배열
+    let thumbnails: [UIImage]
+
+    // 실제 재생되는 길이
     var trimmedDuration: Double {
         max(0, endPoint - startPoint)
     }

--- a/Chalkak/Presentation/ProjectEdit/Model/EditableClip.swift
+++ b/Chalkak/Presentation/ProjectEdit/Model/EditableClip.swift
@@ -1,0 +1,39 @@
+//
+//  EditableClip.swift
+//  Chalkak
+//
+//  Created by 배현진 on 7/24/25.
+//
+
+import Foundation
+
+struct EditableClip: Identifiable, Equatable {
+    let id: String
+    let url: URL
+    var startPoint: Double
+    var endPoint: Double
+    let originalDuration: Double
+    let createdAt: Date
+
+    var isTrimming: Bool = false
+
+    var duration: Double {
+        endPoint - startPoint
+    }
+
+    /// 타임라인 상에서의 위치 계산을 위한 프로퍼티 (총 영상 내 상대 위치 계산용)
+    var timelineRange: ClosedRange<Double> {
+        startPoint...endPoint
+    }
+}
+
+extension EditableClip {
+    init(from clip: Clip) {
+        self.id = clip.id
+        self.url = clip.videoURL
+        self.startPoint = clip.startPoint
+        self.endPoint = clip.endPoint
+        self.originalDuration = clip.endPoint
+        self.createdAt = clip.createdAt
+    }
+}

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
@@ -15,17 +15,16 @@ struct ProjectEditView: View {
         VStack(spacing: 0) {
             Spacer().frame(height: 16)
 
-            // 프리뷰 영상
             VideoPreviewView(
                 previewImage: viewModel.previewImage,
                 player: viewModel.player,
                 isDragging: viewModel.isDragging,
                 overlayImage: nil
             )
+            .frame(maxWidth: .infinity, maxHeight: 300)
 
             Divider().padding(.vertical, 8)
 
-            // 타임라인 및 시간 표시P
             TrimminglineSliderView(
                 clips: $viewModel.editableClips,
                 playHeadPosition: $viewModel.playHead,
@@ -39,16 +38,13 @@ struct ProjectEditView: View {
 
             Divider()
 
-            // 재생 컨트롤
             PlayButtonControlView(
                 isPlaying: $viewModel.isPlaying,
                 onPlayPauseTapped: viewModel.togglePlayback
             )
         }
         .padding(.horizontal, 16)
-        .onAppear {
-            viewModel.loadProject()
-        }
+        .onAppear { viewModel.loadProject() }
         .navigationTitle("프로젝트 트리밍")
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
@@ -22,7 +22,6 @@ struct ProjectEditView: View {
                 isDragging: viewModel.isDragging,
                 overlayImage: nil
             )
-            .frame(maxWidth: .infinity, maxHeight: 300)
 
             Divider().padding(.vertical, 8)
 

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
@@ -10,6 +10,7 @@ import AVKit
 
 struct ProjectEditView: View {
     @StateObject private var viewModel = ProjectEditViewModel()
+    @EnvironmentObject private var coordinator: Coordinator
 
     var body: some View {
         VStack(spacing: 0) {
@@ -33,7 +34,10 @@ struct ProjectEditView: View {
                 totalDuration: viewModel.totalDuration,
                 onSeek: viewModel.seekTo,
                 onToggleTrimming: viewModel.toggleTrimmingMode,
-                onTrimChanged: viewModel.updateTrimRange
+                onTrimChanged: viewModel.updateTrimRange,
+                onAddClipTapped: {
+                    coordinator.push(.boundingBox(guide: viewModel.guide ?? nil))
+                }
             )
 
             Divider()

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
@@ -1,0 +1,55 @@
+//
+//  ProjectEditView.swift
+//  Chalkak
+//
+//  Created by 배현진 on 7/24/25.
+//
+
+import SwiftUI
+import AVKit
+
+struct ProjectEditView: View {
+    @StateObject private var viewModel = ProjectEditViewModel()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer().frame(height: 16)
+
+            // 프리뷰 영상
+            VideoPreviewView(
+                previewImage: viewModel.previewImage,
+                player: viewModel.player,
+                isDragging: viewModel.isDragging,
+                overlayImage: nil
+            )
+
+            Divider().padding(.vertical, 8)
+
+            // 타임라인 및 시간 표시P
+            TrimminglineSliderView(
+                clips: $viewModel.editableClips,
+                playHeadPosition: $viewModel.playHead,
+                isDragging: $viewModel.isDragging,
+                isPlaying: viewModel.isPlaying,
+                totalDuration: viewModel.totalDuration,
+                onSeek: viewModel.seekTo,
+                onToggleTrimming: viewModel.toggleTrimmingMode,
+                onTrimChanged: viewModel.updateTrimRange
+            )
+
+            Divider()
+
+            // 재생 컨트롤
+            PlayButtonControlView(
+                isPlaying: $viewModel.isPlaying,
+                onPlayPauseTapped: viewModel.togglePlayback
+            )
+        }
+        .padding(.horizontal, 16)
+        .onAppear {
+            viewModel.loadProject()
+        }
+        .navigationTitle("프로젝트 트리밍")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
@@ -23,6 +23,17 @@ struct ProjectEditView: View {
                 overlayImage: nil
             )
 
+            PlayButtonControlView(
+                isPlaying: $viewModel.isPlaying,
+                onPlayPauseTapped: viewModel.togglePlayback
+            )
+            
+            PlayTimeView(
+                currentTime: viewModel.playHead,
+                totalDuration: viewModel.totalDuration,
+                trimmingClip: viewModel.editableClips.first(where: { $0.isTrimming })
+            )
+            
             Divider().padding(.vertical, 8)
 
             TrimminglineSliderView(
@@ -37,13 +48,6 @@ struct ProjectEditView: View {
                 onAddClipTapped: {
                     coordinator.push(.boundingBox(guide: viewModel.guide ?? nil))
                 }
-            )
-
-            Divider()
-
-            PlayButtonControlView(
-                isPlaying: $viewModel.isPlaying,
-                onPlayPauseTapped: viewModel.togglePlayback
             )
         }
         .padding(.horizontal, 16)

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
@@ -16,12 +16,33 @@ struct ProjectEditView: View {
         VStack(spacing: 0) {
             Spacer().frame(height: 16)
 
-            VideoPreviewView(
-                previewImage: viewModel.previewImage,
-                player: viewModel.player,
-                isDragging: viewModel.isDragging,
-                overlayImage: nil
-            )
+            ZStack {
+                VideoPreviewView(
+                    previewImage: viewModel.previewImage,
+                    player: viewModel.player,
+                    isDragging: viewModel.isDragging,
+                    overlayImage: nil
+                )
+                
+                // 선택된 클립이 있을 때만 Delete 버튼 표시
+                if let trimmingClip = viewModel.editableClips.first(where: { $0.isTrimming }) {
+                    HStack {
+                        Spacer()
+                        Button(action: {
+                            viewModel.deleteClip(id: trimmingClip.id)
+                        }) {
+                            Image(systemName: "trash")
+                                .foregroundColor(.red)
+                                .imageScale(.large)
+                                .padding()
+                                .background(Color(.systemGray6))
+                                .clipShape(Circle())
+                        }
+                        Spacer()
+                    }
+                    .padding(.bottom, 8)
+                }
+            }
 
             PlayButtonControlView(
                 isPlaying: $viewModel.isPlaying,

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
@@ -114,11 +114,14 @@ final class ProjectEditViewModel: ObservableObject {
         }
 
         currentComposition = composition
+        let previewComposition = composition.makePreviewVideoComposition(using: editableClips)
         let item = AVPlayerItem(asset: composition)
+        item.videoComposition = previewComposition
         player.replaceCurrentItem(with: item)
 
         imageGenerator = AVAssetImageGenerator(asset: composition)
         imageGenerator?.appliesPreferredTrackTransform = true
+        imageGenerator?.videoComposition = previewComposition
 
         Task { await updatePreviewImage(at: playHead) }
 

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
@@ -12,6 +12,9 @@ import SwiftUI
 @MainActor
 final class ProjectEditViewModel: ObservableObject {
     private var project: Project?
+    private var currentComposition: AVMutableComposition?
+    private var timeObserverToken: Any?
+    private var imageGenerator: AVAssetImageGenerator?
     
     @Published var editableClips: [EditableClip] = []
     @Published var isPlaying = false
@@ -20,10 +23,10 @@ final class ProjectEditViewModel: ObservableObject {
     @Published var previewImage: UIImage? = nil
     @Published var isDragging = false
     @Published var guide: Guide? = nil
-
-    private var currentComposition: AVMutableComposition?
-    private var timeObserverToken: Any?
-    private var imageGenerator: AVAssetImageGenerator?
+    
+    var totalDuration: Double {
+        editableClips.reduce(0) { $0 + $1.trimmedDuration }
+    }
 
     func loadProject() {
         guard
@@ -205,8 +208,11 @@ final class ProjectEditViewModel: ObservableObject {
         editableClips[idx].endPoint   = max(0, min(end,   editableClips[idx].originalDuration))
         setupPlayer()
     }
-
-    var totalDuration: Double {
-        editableClips.reduce(0) { $0 + $1.trimmedDuration }
+    
+    func deleteClip(id: String) {
+        if let idx = editableClips.firstIndex(where: { $0.id == id }) {
+            editableClips.remove(at: idx)
+            setupPlayer()
+        }
     }
 }

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
@@ -11,104 +11,87 @@ import SwiftUI
 
 @MainActor
 final class ProjectEditViewModel: ObservableObject {
-    
-    // MARK: - Published 상태
-    
     @Published var editableClips: [EditableClip] = []
-    @Published var isPlaying: Bool = false
+    @Published var isPlaying = false
     @Published var playHead: Double = 0
-    @Published var player: AVPlayer = AVPlayer()
+    @Published var player = AVPlayer()
     @Published var previewImage: UIImage? = nil
-    @Published var isDragging: Bool = false
-    private var imageGenerator: AVAssetImageGenerator?
-    
-    // MARK: - 내부 상태
+    @Published var isDragging = false
+
     private var currentComposition: AVMutableComposition?
     private var timeObserverToken: Any?
+    private var imageGenerator: AVAssetImageGenerator?
     
-    // MARK: - 로직
-
-    /// 프로젝트 로드 및 클립 초기화
+    // MARK: - 프로젝트 로드
     func loadProject() {
-        guard let projectID = UserDefaults.standard.string(forKey: "currentProjectID"),
-              let project = SwiftDataManager.shared.fetchProject(byID: projectID) else {
-            print("프로젝트를 찾을 수 없습니다.")
-            return
+        guard
+            let projectID = UserDefaults.standard.string(forKey: "currentProjectID"),
+            let project = SwiftDataManager.shared.fetchProject(byID: projectID)
+        else { return }
+        
+        let sorted = project.clipList.sorted { $0.createdAt < $1.createdAt }
+        editableClips = sorted.map { clip in
+            EditableClip(
+                id: clip.id,
+                url: clip.videoURL,
+                originalDuration: clip.originalDuration,
+                startPoint: clip.startPoint,
+                endPoint: clip.endPoint
+            )
         }
-
-        let sortedClips = project.clipList.sorted { $0.createdAt < $1.createdAt }
-
-        self.editableClips = sortedClips.map { EditableClip(from: $0) }
-
+        
         setupPlayer()
     }
-
-    /// AVComposition 생성 및 Player 세팅
+    
+    // MARK: - Composition 생성 & Player 세팅
     func setupPlayer() {
-            // 새로운 Composition
-            let composition = AVMutableComposition()
-            guard
-                let compVideoTrack = composition.addMutableTrack(
-                    withMediaType: .video,
-                    preferredTrackID: kCMPersistentTrackID_Invalid
-                ),
-                let compAudioTrack = composition.addMutableTrack(
-                    withMediaType: .audio,
-                    preferredTrackID: kCMPersistentTrackID_Invalid
-                )
-            else {
-                print("트랙 생성에 실패했습니다.")
-                return
-            }
-
-            // 순서대로 클립 삽입
-            var cursor = CMTime.zero
-            for clip in editableClips {
-                let asset = AVAsset(url: clip.url)
-                let start = CMTime(seconds: clip.startPoint, preferredTimescale: 600)
-                let duration = CMTime(seconds: clip.duration, preferredTimescale: 600)
-                let timeRange = CMTimeRange(start: start, duration: duration)
-
-                do {
-                    // 비디오
-                    if let videoAssetTrack = asset.tracks(withMediaType: .video).first {
-                        try compVideoTrack.insertTimeRange(
-                            timeRange,
-                            of: videoAssetTrack,
-                            at: cursor
-                        )
-                    } else {
-                        print("\(clip.id) 비디오 트랙이 없습니다.")
-                    }
-
-                    // 오디오
-                    if let audioAssetTrack = asset.tracks(withMediaType: .audio).first {
-                        try compAudioTrack.insertTimeRange(
-                            timeRange,
-                            of: audioAssetTrack,
-                            at: cursor
-                        )
-                    }
-
-                    cursor = CMTimeAdd(cursor, duration)
-                } catch {
-                    print("클립 삽입 중 에러 (\(clip.id)): \(error)")
-                }
-            }
-
-            // AVPlayerItem 교체
-            currentComposition = composition
-            let playerItem = AVPlayerItem(asset: composition)
-            player.replaceCurrentItem(with: playerItem)
-
-            // timeObserver 재등록
-            if let token = timeObserverToken {
-                player.removeTimeObserver(token)
-            }
-            addTimeObserver()
+        let composition = AVMutableComposition()
+        guard
+            let vidTrack = composition.addMutableTrack(
+                withMediaType: .video, preferredTrackID: kCMPersistentTrackID_Invalid),
+            let audTrack = composition.addMutableTrack(
+                withMediaType: .audio, preferredTrackID: kCMPersistentTrackID_Invalid)
+        else {
+            print("트랙 생성 실패")
+            return
         }
-
-    /// AVPlayer 재생 시간 감지
+        
+        // 순차적으로 삽입
+        var cursor = CMTime.zero
+        for clip in editableClips {
+            let asset = AVAsset(url: clip.url)
+            let start = CMTime(seconds: clip.startPoint, preferredTimescale: 600)
+            let dur   = CMTime(seconds: clip.trimmedDuration, preferredTimescale: 600)
+            let range = CMTimeRange(start: start, duration: dur)
+            
+            if let t = asset.tracks(withMediaType: .video).first {
+                try? vidTrack.insertTimeRange(range, of: t, at: cursor)
+            }
+            if let t = asset.tracks(withMediaType: .audio).first {
+                try? audTrack.insertTimeRange(range, of: t, at: cursor)
+            }
+            cursor = cursor + dur
+        }
+        
+        currentComposition = composition
+        let item = AVPlayerItem(asset: composition)
+        player.replaceCurrentItem(with: item)
+        
+        // ▶️ ImageGenerator 갱신
+        imageGenerator = AVAssetImageGenerator(asset: composition)
+        imageGenerator?.appliesPreferredTrackTransform = true
+        
+        // ▶️ 현재 프레임 즉시 뽑아오기
+        Task { await updatePreviewImage(at: playHead) }
+        
+        // ▶️ 시간 옵저버 재등록
+        if let token = timeObserverToken {
+            player.removeTimeObserver(token)
+        }
+        addTimeObserver()
+    }
+    
+    // MARK: - 시간 옵저빙 & Preview 업데이트
     private func addTimeObserver() {
         let interval = CMTime(seconds: 0.05, preferredTimescale: 600)
         timeObserverToken = player.addPeriodicTimeObserver(forInterval: interval, queue: .main) { [weak self] time in
@@ -116,60 +99,56 @@ final class ProjectEditViewModel: ObservableObject {
             let seconds = CMTimeGetSeconds(time)
             self.playHead = seconds
             
+            // ▶️ 프리뷰 이미지 업데이트
+            Task { await self.updatePreviewImage(at: seconds) }
+            
+            // ▶️ 끝나면 자동 정지
             if seconds >= self.totalDuration {
                 self.isPlaying = false
                 self.player.pause()
             }
-            
-            Task {
-                await self.updatePreviewImage(at: seconds)
-            }
         }
     }
-
-    /// 재생 위치 이동
-    func seekTo(time: Double) {
-        let cmTime = CMTime(seconds: time, preferredTimescale: 600)
-        player.seek(to: cmTime, toleranceBefore: .zero, toleranceAfter: .zero)
-        playHead = time
+    
+    func updatePreviewImage(at time: Double) async {
+        guard let gen = imageGenerator else { return }
+        let cm = CMTime(seconds: time, preferredTimescale: 600)
+        if let cg = try? gen.copyCGImage(at: cm, actualTime: nil) {
+            self.previewImage = UIImage(cgImage: cg)
+        }
     }
-
-    /// 재생/정지 토글
+    
+    // MARK: - 제어 액션
     func togglePlayback() {
         isPlaying.toggle()
         isPlaying ? player.play() : player.pause()
     }
-
-    /// 트리밍 모드 ON/OFF
-    func toggleTrimmingMode(for clipID: String) {
-        guard let index = editableClips.firstIndex(where: { $0.id == clipID }) else { return }
-        editableClips[index].isTrimming.toggle()
-    }
-
-    /// 트리밍 범위 갱신
-    func updateTrimRange(for clipID: String, start: Double, end: Double) {
-        guard let index = editableClips.firstIndex(where: { $0.id == clipID }) else { return }
-
-        editableClips[index].startPoint = max(0, min(start, editableClips[index].originalDuration))
-        editableClips[index].endPoint = max(0, min(end, editableClips[index].originalDuration))
-
-        /// 트리밍 반영되었으므로 Composition 다시 생성
-        setupPlayer()
-    }
-
-    /// 전체 영상 길이 계산
-    var totalDuration: Double {
-        editableClips.reduce(0) { $0 + $1.duration }
+    
+    func seekTo(time: Double) {
+        let cm = CMTime(seconds: time, preferredTimescale: 600)
+        player.seek(to: cm, toleranceBefore: .zero, toleranceAfter: .zero)
+        playHead = time
     }
     
-    func updatePreviewImage(at time: Double) async {
-        let cmTime = CMTime(seconds: time, preferredTimescale: 600)
-        do {
-            if let cgImage = try imageGenerator?.copyCGImage(at: cmTime, actualTime: nil) {
-                self.previewImage = UIImage(cgImage: cgImage)
-            }
-        } catch {
-            print("preview image 생성 실패: \(error)")
+    /// 단일 클립만 트리밍 모드 on/off
+    func toggleTrimmingMode(for clipID: String) {
+        editableClips = editableClips.map { clip in
+            var c = clip
+            c.isTrimming = (clip.id == clipID) ? !clip.isTrimming : false
+            return c
         }
+    }
+    
+    /// 트리밍 범위 갱신 → Composition 재생성
+    func updateTrimRange(for clipID: String, start: Double, end: Double) {
+        guard let idx = editableClips.firstIndex(where: { $0.id == clipID }) else { return }
+        editableClips[idx].startPoint = max(0, min(start, editableClips[idx].originalDuration))
+        editableClips[idx].endPoint   = max(0, min(end,   editableClips[idx].originalDuration))
+        setupPlayer()
+    }
+    
+    /// 전체 길이
+    var totalDuration: Double {
+        editableClips.reduce(0) { $0 + $1.trimmedDuration }
     }
 }

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
@@ -1,0 +1,175 @@
+//
+//  ProjectEditViewModel.swift
+//  Chalkak
+//
+//  Created by 배현진 on 7/24/25.
+//
+
+import Foundation
+import AVFoundation
+import SwiftUI
+
+@MainActor
+final class ProjectEditViewModel: ObservableObject {
+    
+    // MARK: - Published 상태
+    
+    @Published var editableClips: [EditableClip] = []
+    @Published var isPlaying: Bool = false
+    @Published var playHead: Double = 0
+    @Published var player: AVPlayer = AVPlayer()
+    @Published var previewImage: UIImage? = nil
+    @Published var isDragging: Bool = false
+    private var imageGenerator: AVAssetImageGenerator?
+    
+    // MARK: - 내부 상태
+    private var currentComposition: AVMutableComposition?
+    private var timeObserverToken: Any?
+    
+    // MARK: - 로직
+
+    /// 프로젝트 로드 및 클립 초기화
+    func loadProject() {
+        guard let projectID = UserDefaults.standard.string(forKey: "currentProjectID"),
+              let project = SwiftDataManager.shared.fetchProject(byID: projectID) else {
+            print("프로젝트를 찾을 수 없습니다.")
+            return
+        }
+
+        let sortedClips = project.clipList.sorted { $0.createdAt < $1.createdAt }
+
+        self.editableClips = sortedClips.map { EditableClip(from: $0) }
+
+        setupPlayer()
+    }
+
+    /// AVComposition 생성 및 Player 세팅
+    func setupPlayer() {
+            // 새로운 Composition
+            let composition = AVMutableComposition()
+            guard
+                let compVideoTrack = composition.addMutableTrack(
+                    withMediaType: .video,
+                    preferredTrackID: kCMPersistentTrackID_Invalid
+                ),
+                let compAudioTrack = composition.addMutableTrack(
+                    withMediaType: .audio,
+                    preferredTrackID: kCMPersistentTrackID_Invalid
+                )
+            else {
+                print("트랙 생성에 실패했습니다.")
+                return
+            }
+
+            // 순서대로 클립 삽입
+            var cursor = CMTime.zero
+            for clip in editableClips {
+                let asset = AVAsset(url: clip.url)
+                let start = CMTime(seconds: clip.startPoint, preferredTimescale: 600)
+                let duration = CMTime(seconds: clip.duration, preferredTimescale: 600)
+                let timeRange = CMTimeRange(start: start, duration: duration)
+
+                do {
+                    // 비디오
+                    if let videoAssetTrack = asset.tracks(withMediaType: .video).first {
+                        try compVideoTrack.insertTimeRange(
+                            timeRange,
+                            of: videoAssetTrack,
+                            at: cursor
+                        )
+                    } else {
+                        print("\(clip.id) 비디오 트랙이 없습니다.")
+                    }
+
+                    // 오디오
+                    if let audioAssetTrack = asset.tracks(withMediaType: .audio).first {
+                        try compAudioTrack.insertTimeRange(
+                            timeRange,
+                            of: audioAssetTrack,
+                            at: cursor
+                        )
+                    }
+
+                    cursor = CMTimeAdd(cursor, duration)
+                } catch {
+                    print("클립 삽입 중 에러 (\(clip.id)): \(error)")
+                }
+            }
+
+            // AVPlayerItem 교체
+            currentComposition = composition
+            let playerItem = AVPlayerItem(asset: composition)
+            player.replaceCurrentItem(with: playerItem)
+
+            // timeObserver 재등록
+            if let token = timeObserverToken {
+                player.removeTimeObserver(token)
+            }
+            addTimeObserver()
+        }
+
+    /// AVPlayer 재생 시간 감지
+    private func addTimeObserver() {
+        let interval = CMTime(seconds: 0.05, preferredTimescale: 600)
+        timeObserverToken = player.addPeriodicTimeObserver(forInterval: interval, queue: .main) { [weak self] time in
+            guard let self = self else { return }
+            let seconds = CMTimeGetSeconds(time)
+            self.playHead = seconds
+            
+            if seconds >= self.totalDuration {
+                self.isPlaying = false
+                self.player.pause()
+            }
+            
+            Task {
+                await self.updatePreviewImage(at: seconds)
+            }
+        }
+    }
+
+    /// 재생 위치 이동
+    func seekTo(time: Double) {
+        let cmTime = CMTime(seconds: time, preferredTimescale: 600)
+        player.seek(to: cmTime, toleranceBefore: .zero, toleranceAfter: .zero)
+        playHead = time
+    }
+
+    /// 재생/정지 토글
+    func togglePlayback() {
+        isPlaying.toggle()
+        isPlaying ? player.play() : player.pause()
+    }
+
+    /// 트리밍 모드 ON/OFF
+    func toggleTrimmingMode(for clipID: String) {
+        guard let index = editableClips.firstIndex(where: { $0.id == clipID }) else { return }
+        editableClips[index].isTrimming.toggle()
+    }
+
+    /// 트리밍 범위 갱신
+    func updateTrimRange(for clipID: String, start: Double, end: Double) {
+        guard let index = editableClips.firstIndex(where: { $0.id == clipID }) else { return }
+
+        editableClips[index].startPoint = max(0, min(start, editableClips[index].originalDuration))
+        editableClips[index].endPoint = max(0, min(end, editableClips[index].originalDuration))
+
+        /// 트리밍 반영되었으므로 Composition 다시 생성
+        setupPlayer()
+    }
+
+    /// 전체 영상 길이 계산
+    var totalDuration: Double {
+        editableClips.reduce(0) { $0 + $1.duration }
+    }
+    
+    func updatePreviewImage(at time: Double) async {
+        let cmTime = CMTime(seconds: time, preferredTimescale: 600)
+        do {
+            if let cgImage = try imageGenerator?.copyCGImage(at: cmTime, actualTime: nil) {
+                self.previewImage = UIImage(cgImage: cgImage)
+            }
+        } catch {
+            print("preview image 생성 실패: \(error)")
+        }
+    }
+}

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
@@ -164,6 +164,9 @@ final class ProjectEditViewModel: ObservableObject {
         let cm = CMTime(seconds: time, preferredTimescale: 600)
         player.seek(to: cm, toleranceBefore: .zero, toleranceAfter: .zero)
         playHead = time
+        Task {
+            await updatePreviewImage(at: time)
+        }
     }
 
     func toggleTrimmingMode(for clipID: String) {

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
@@ -11,12 +11,15 @@ import SwiftUI
 
 @MainActor
 final class ProjectEditViewModel: ObservableObject {
+    private var project: Project?
+    
     @Published var editableClips: [EditableClip] = []
     @Published var isPlaying = false
     @Published var playHead: Double = 0
     @Published var player = AVPlayer()
     @Published var previewImage: UIImage? = nil
     @Published var isDragging = false
+    @Published var guide: Guide? = nil
 
     private var currentComposition: AVMutableComposition?
     private var timeObserverToken: Any?
@@ -30,6 +33,9 @@ final class ProjectEditViewModel: ObservableObject {
             print("프로젝트를 찾을 수 없습니다.")
             return
         }
+        
+        self.project = project
+        self.guide = project.guide
 
         let sorted = project.clipList.sorted { $0.createdAt < $1.createdAt }
 
@@ -98,11 +104,11 @@ final class ProjectEditViewModel: ObservableObject {
             let dur   = CMTime(seconds: clip.trimmedDuration, preferredTimescale: 600)
             let range = CMTimeRange(start: start, duration: dur)
 
-            if let t = asset.tracks(withMediaType: .video).first {
-                try? vidTrack.insertTimeRange(range, of: t, at: cursor)
+            if let track = asset.tracks(withMediaType: .video).first {
+                try? vidTrack.insertTimeRange(range, of: track, at: cursor)
             }
-            if let t = asset.tracks(withMediaType: .audio).first {
-                try? audTrack.insertTimeRange(range, of: t, at: cursor)
+            if let track = asset.tracks(withMediaType: .audio).first {
+                try? audTrack.insertTimeRange(range, of: track, at: cursor)
             }
             cursor = cursor + dur
         }

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
@@ -21,49 +21,83 @@ final class ProjectEditViewModel: ObservableObject {
     private var currentComposition: AVMutableComposition?
     private var timeObserverToken: Any?
     private var imageGenerator: AVAssetImageGenerator?
-    
-    // MARK: - 프로젝트 로드
+
     func loadProject() {
         guard
             let projectID = UserDefaults.standard.string(forKey: "currentProjectID"),
             let project = SwiftDataManager.shared.fetchProject(byID: projectID)
-        else { return }
-        
+        else {
+            print("프로젝트를 찾을 수 없습니다.")
+            return
+        }
+
         let sorted = project.clipList.sorted { $0.createdAt < $1.createdAt }
+
+        // 썸네일 미리 생성
         editableClips = sorted.map { clip in
-            EditableClip(
+            let thumbs = generateThumbnails(
+                url: clip.videoURL,
+                duration: clip.originalDuration,
+                count: 10
+            )
+            return EditableClip(
                 id: clip.id,
                 url: clip.videoURL,
                 originalDuration: clip.originalDuration,
                 startPoint: clip.startPoint,
-                endPoint: clip.endPoint
+                endPoint: clip.endPoint,
+                thumbnails: thumbs
             )
         }
-        
+
         setupPlayer()
     }
-    
-    // MARK: - Composition 생성 & Player 세팅
+
+    private func generateThumbnails(
+        url: URL,
+        duration: Double,
+        count: Int
+    ) -> [UIImage] {
+        let asset = AVAsset(url: url)
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        generator.requestedTimeToleranceBefore = .zero
+        generator.requestedTimeToleranceAfter = .zero
+
+        var imgs: [UIImage] = []
+        let interval = duration / Double(count)
+        for i in 0..<count {
+            let time = CMTime(seconds: Double(i) * interval, preferredTimescale: 600)
+            if let cg = try? generator.copyCGImage(at: time, actualTime: nil) {
+                imgs.append(UIImage(cgImage: cg))
+            }
+        }
+        return imgs
+    }
+
     func setupPlayer() {
         let composition = AVMutableComposition()
         guard
             let vidTrack = composition.addMutableTrack(
-                withMediaType: .video, preferredTrackID: kCMPersistentTrackID_Invalid),
+                withMediaType: .video,
+                preferredTrackID: kCMPersistentTrackID_Invalid
+            ),
             let audTrack = composition.addMutableTrack(
-                withMediaType: .audio, preferredTrackID: kCMPersistentTrackID_Invalid)
+                withMediaType: .audio,
+                preferredTrackID: kCMPersistentTrackID_Invalid
+            )
         else {
             print("트랙 생성 실패")
             return
         }
-        
-        // 순차적으로 삽입
+
         var cursor = CMTime.zero
         for clip in editableClips {
             let asset = AVAsset(url: clip.url)
             let start = CMTime(seconds: clip.startPoint, preferredTimescale: 600)
             let dur   = CMTime(seconds: clip.trimmedDuration, preferredTimescale: 600)
             let range = CMTimeRange(start: start, duration: dur)
-            
+
             if let t = asset.tracks(withMediaType: .video).first {
                 try? vidTrack.insertTimeRange(range, of: t, at: cursor)
             }
@@ -72,82 +106,75 @@ final class ProjectEditViewModel: ObservableObject {
             }
             cursor = cursor + dur
         }
-        
+
         currentComposition = composition
         let item = AVPlayerItem(asset: composition)
         player.replaceCurrentItem(with: item)
-        
-        // ▶️ ImageGenerator 갱신
+
         imageGenerator = AVAssetImageGenerator(asset: composition)
         imageGenerator?.appliesPreferredTrackTransform = true
-        
-        // ▶️ 현재 프레임 즉시 뽑아오기
+
         Task { await updatePreviewImage(at: playHead) }
-        
-        // ▶️ 시간 옵저버 재등록
+
         if let token = timeObserverToken {
             player.removeTimeObserver(token)
         }
         addTimeObserver()
     }
-    
-    // MARK: - 시간 옵저빙 & Preview 업데이트
+
     private func addTimeObserver() {
         let interval = CMTime(seconds: 0.05, preferredTimescale: 600)
-        timeObserverToken = player.addPeriodicTimeObserver(forInterval: interval, queue: .main) { [weak self] time in
+        timeObserverToken = player.addPeriodicTimeObserver(
+            forInterval: interval,
+            queue: .main
+        ) { [weak self] time in
             guard let self = self else { return }
-            let seconds = CMTimeGetSeconds(time)
-            self.playHead = seconds
-            
-            // ▶️ 프리뷰 이미지 업데이트
-            Task { await self.updatePreviewImage(at: seconds) }
-            
-            // ▶️ 끝나면 자동 정지
-            if seconds >= self.totalDuration {
+            let secs = CMTimeGetSeconds(time)
+            self.playHead = secs
+            Task { await self.updatePreviewImage(at: secs) }
+            if secs >= self.totalDuration {
                 self.isPlaying = false
                 self.player.pause()
             }
         }
     }
-    
+
     func updatePreviewImage(at time: Double) async {
         guard let gen = imageGenerator else { return }
         let cm = CMTime(seconds: time, preferredTimescale: 600)
         if let cg = try? gen.copyCGImage(at: cm, actualTime: nil) {
-            self.previewImage = UIImage(cgImage: cg)
+            await MainActor.run {
+                self.previewImage = UIImage(cgImage: cg)
+            }
         }
     }
-    
-    // MARK: - 제어 액션
+
     func togglePlayback() {
         isPlaying.toggle()
-        isPlaying ? player.play() : player.pause()
+        if isPlaying { player.play() } else { player.pause() }
     }
-    
+
     func seekTo(time: Double) {
         let cm = CMTime(seconds: time, preferredTimescale: 600)
         player.seek(to: cm, toleranceBefore: .zero, toleranceAfter: .zero)
         playHead = time
     }
-    
-    /// 단일 클립만 트리밍 모드 on/off
+
     func toggleTrimmingMode(for clipID: String) {
         editableClips = editableClips.map { clip in
             var c = clip
-            c.isTrimming = (clip.id == clipID) ? !clip.isTrimming : false
+            c.isTrimming = (c.id == clipID) ? !c.isTrimming : false
             return c
         }
     }
-    
-    /// 트리밍 범위 갱신 → Composition 재생성
+
     func updateTrimRange(for clipID: String, start: Double, end: Double) {
         guard let idx = editableClips.firstIndex(where: { $0.id == clipID }) else { return }
         editableClips[idx].startPoint = max(0, min(start, editableClips[idx].originalDuration))
         editableClips[idx].endPoint   = max(0, min(end,   editableClips[idx].originalDuration))
         setupPlayer()
     }
-    
-    /// 전체 길이
+
     var totalDuration: Double {
         editableClips.reduce(0) { $0 + $1.trimmedDuration }
     }

--- a/Chalkak/Presentation/ProjectEdit/SubViews/ClipTrimmingView.swift
+++ b/Chalkak/Presentation/ProjectEdit/SubViews/ClipTrimmingView.swift
@@ -18,87 +18,26 @@ struct ClipTrimmingView: View {
     private let clipSpacing: CGFloat = 8
     private let thumbnailHeight: CGFloat = 60
 
-    /// 뷰 전체 너비 (고정)
     private var fullWidth: CGFloat {
         CGFloat(clip.originalDuration) * pxPerSecond
     }
 
     var body: some View {
         ZStack(alignment: .leading) {
-            // 1) 전체 썸네일
-            HStack(spacing: 0) {
-                ForEach(clip.thumbnails.indices, id: \.self) { i in
-                    Image(uiImage: clip.thumbnails[i])
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .frame(
-                            width: fullWidth / CGFloat(clip.thumbnails.count),
-                            height: thumbnailHeight
-                        )
-                        .clipped()
-                }
-            }
-            .frame(width: fullWidth, height: thumbnailHeight)
-            .contentShape(Rectangle())
-            .onTapGesture { onToggleTrimming() }
-            .padding(.horizontal, clipSpacing/2)
+            ProjectThumbnailsView(clip: clip, fullWidth: fullWidth)
+                .onTapGesture { onToggleTrimming() }
+                .padding(.horizontal, clipSpacing/2)
 
-            // 2) 마스크 & 테두리 & 핸들 (트리밍 모드일 때만)
             if clip.isTrimming {
-                let leftW  = CGFloat(clip.startPoint / clip.originalDuration) * fullWidth
-                let midW   = CGFloat(clip.trimmedDuration / clip.originalDuration) * fullWidth
-                let rightW = fullWidth - leftW - midW
-
-                // 어두운 마스크
-                HStack(spacing: 0) {
-                    Color.black.opacity(0.5).frame(width: leftW)
-                    Color.clear.frame(width: midW)
-                    Color.black.opacity(0.5).frame(width: rightW)
-                }
-                .frame(width: fullWidth, height: thumbnailHeight)
-
-                // 노란 테두리
-                RoundedRectangle(cornerRadius: 4)
-                    .stroke(Color.yellow, lineWidth: 2)
-                    .frame(width: midW, height: thumbnailHeight)
-                    .offset(x: leftW)
-
-                // 핸들 (시작/끝)
-                handle(isStart: true,  leftW: leftW, midW: midW)
-                handle(isStart: false, leftW: leftW, midW: midW)
+                ProjectTrimmingLineView(
+                    clip: clip,
+                    fullWidth: fullWidth,
+                    thumbnailHeight: thumbnailHeight,
+                    isDragging: $isDragging,
+                    onTrimChanged: onTrimChanged
+                )
             }
         }
         .frame(width: fullWidth, height: thumbnailHeight)
-    }
-
-    @ViewBuilder
-    private func handle(isStart: Bool, leftW: CGFloat, midW: CGFloat) -> some View {
-        let size: CGFloat = 10
-        let xOffset = isStart
-            ? leftW
-            : (leftW + midW - size)
-
-        RoundedRectangle(cornerRadius: 3)
-            .fill(Color.yellow)
-            .frame(width: size, height: thumbnailHeight)
-            .offset(x: xOffset)
-            .gesture(
-                DragGesture()
-                    .onChanged { g in
-                        isDragging = true
-                        let ratio = min(max(g.location.x / fullWidth, 0), 1)
-                        let t = Double(ratio) * clip.originalDuration
-                        if isStart {
-                            let newStart = min(t, clip.endPoint - 0.1)
-                            onTrimChanged(newStart, clip.endPoint)
-                        } else {
-                            let newEnd = max(t, clip.startPoint + 0.1)
-                            onTrimChanged(clip.startPoint, newEnd)
-                        }
-                    }
-                    .onEnded { _ in
-                        isDragging = false
-                    }
-            )
     }
 }

--- a/Chalkak/Presentation/ProjectEdit/SubViews/ClipTrimmingView.swift
+++ b/Chalkak/Presentation/ProjectEdit/SubViews/ClipTrimmingView.swift
@@ -1,0 +1,138 @@
+//
+//  ClipTrimmingView.swift
+//  Chalkak
+//
+//  Created by 배현진 on 7/24/25.
+//
+
+import SwiftUI
+import AVFoundation
+
+struct ClipTrimmingView: View {
+    let clip: EditableClip
+    let isTrimming: Bool
+    let isDragging: Binding<Bool>
+    let onToggleTrimming: () -> Void
+    let onTrimChanged: (_ newStart: Double, _ newEnd: Double) -> Void
+
+    @State private var thumbnails: [UIImage] = []
+    @State private var width: CGFloat = 160
+
+    private let thumbnailCount = 10
+    private let thumbnailHeight: CGFloat = 60
+
+    var body: some View {
+        ZStack(alignment: .leading) {
+            // 썸네일
+            HStack(spacing: 0) {
+                ForEach(thumbnails.indices, id: \.self) { index in
+                    Image(uiImage: thumbnails[index])
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: thumbnailWidth, height: thumbnailHeight)
+                        .clipped()
+                }
+            }
+
+            // 트리밍 어두운 영역
+            if isTrimming {
+                let leftRatio = clip.startPoint / clip.originalDuration
+                let rightRatio = 1 - (clip.endPoint / clip.originalDuration)
+
+                HStack(spacing: 0) {
+                    Rectangle()
+                        .fill(Color.black.opacity(0.5))
+                        .frame(width: width * leftRatio)
+
+                    Rectangle()
+                        .fill(Color.clear)
+                        .frame(width: width * (1 - leftRatio - rightRatio))
+
+                    Rectangle()
+                        .fill(Color.black.opacity(0.5))
+                        .frame(width: width * rightRatio)
+                }
+
+                // 트리밍 박스 테두리
+                RoundedRectangle(cornerRadius: 4)
+                    .stroke(Color.yellow, lineWidth: 2)
+                    .frame(
+                        width: width * (clip.endPoint - clip.startPoint) / clip.originalDuration,
+                        height: thumbnailHeight
+                    )
+                    .offset(x: width * clip.startPoint / clip.originalDuration)
+
+                // 핸들 제스처
+                handle(at: .leading)
+                handle(at: .trailing)
+            }
+        }
+        .frame(width: width, height: thumbnailHeight)
+        .onAppear {
+            generateThumbnails()
+        }
+        .contentShape(Rectangle()) // 탭 인식
+        .onTapGesture {
+            onToggleTrimming()
+        }
+    }
+
+    // MARK: - 핸들
+    @ViewBuilder
+    private func handle(at edge: HorizontalAlignment) -> some View {
+        let isStart = edge == .leading
+        let handleSize: CGFloat = 10
+        let offsetX = isStart
+            ? width * clip.startPoint / clip.originalDuration
+            : width * clip.endPoint / clip.originalDuration - handleSize
+
+        RoundedRectangle(cornerRadius: 3)
+            .fill(Color.yellow)
+            .frame(width: handleSize, height: thumbnailHeight)
+            .offset(x: offsetX)
+            .gesture(
+                DragGesture()
+                    .onChanged { gesture in
+                        isDragging.wrappedValue = true
+                        let ratio = max(0, min(gesture.location.x / width, 1))
+                        let time = ratio * clip.originalDuration
+
+                        if isStart {
+                            let newStart = min(time, clip.endPoint - 0.1)
+                            onTrimChanged(newStart, clip.endPoint)
+                        } else {
+                            let newEnd = max(time, clip.startPoint + 0.1)
+                            onTrimChanged(clip.startPoint, newEnd)
+                        }
+                    }
+                    .onEnded { _ in
+                        isDragging.wrappedValue = false  // ✅ 드래그 끝
+                    }
+            )
+    }
+
+    // MARK: - 썸네일 생성
+    private func generateThumbnails() {
+        let asset = AVAsset(url: clip.url)
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        generator.maximumSize = CGSize(width: 100, height: 100)
+
+        let interval = clip.originalDuration / Double(thumbnailCount)
+        let times = (0..<thumbnailCount).map {
+            NSValue(time: CMTime(seconds: Double($0) * interval, preferredTimescale: 600))
+        }
+
+        thumbnails = []
+        for time in times {
+            if let cgImage = try? generator.copyCGImage(at: time.timeValue, actualTime: nil) {
+                thumbnails.append(UIImage(cgImage: cgImage))
+            }
+        }
+    }
+
+    // MARK: - 유틸
+    private var thumbnailWidth: CGFloat {
+        width / CGFloat(thumbnailCount)
+    }
+}

--- a/Chalkak/Presentation/ProjectEdit/SubViews/PlayButtonControlView.swift
+++ b/Chalkak/Presentation/ProjectEdit/SubViews/PlayButtonControlView.swift
@@ -14,10 +14,7 @@ struct PlayButtonControlView: View {
     var body: some View {
         HStack {
             Spacer()
-
-            Button(action: {
-                onPlayPauseTapped()
-            }) {
+            Button(action: onPlayPauseTapped) {
                 Image(systemName: isPlaying ? "pause.fill" : "play.fill")
                     .resizable()
                     .frame(width: 36, height: 36)
@@ -27,7 +24,6 @@ struct PlayButtonControlView: View {
                     .clipShape(Circle())
                     .shadow(radius: 3)
             }
-
             Spacer()
         }
         .padding(.vertical, 12)

--- a/Chalkak/Presentation/ProjectEdit/SubViews/PlayButtonControlView.swift
+++ b/Chalkak/Presentation/ProjectEdit/SubViews/PlayButtonControlView.swift
@@ -1,0 +1,35 @@
+//
+//  PlayButtonControlView.swift
+//  Chalkak
+//
+//  Created by 배현진 on 7/24/25.
+//
+
+import SwiftUI
+
+struct PlayButtonControlView: View {
+    @Binding var isPlaying: Bool
+    let onPlayPauseTapped: () -> Void
+
+    var body: some View {
+        HStack {
+            Spacer()
+
+            Button(action: {
+                onPlayPauseTapped()
+            }) {
+                Image(systemName: isPlaying ? "pause.fill" : "play.fill")
+                    .resizable()
+                    .frame(width: 36, height: 36)
+                    .foregroundColor(.primary)
+                    .padding()
+                    .background(Color(.systemGray6))
+                    .clipShape(Circle())
+                    .shadow(radius: 3)
+            }
+
+            Spacer()
+        }
+        .padding(.vertical, 12)
+    }
+}

--- a/Chalkak/Presentation/ProjectEdit/SubViews/PlayTimeView.swift
+++ b/Chalkak/Presentation/ProjectEdit/SubViews/PlayTimeView.swift
@@ -1,0 +1,38 @@
+//
+//  PlayTimeView.swift
+//  Chalkak
+//
+//  Created by 배현진 on 7/28/25.
+//
+
+import SwiftUI
+
+struct PlayTimeView: View {
+    /// 전체 프로젝트 재생 위치
+    let currentTime: Double
+    /// 전체 프로젝트 길이
+    let totalDuration: Double
+    /// 트리밍 중인 클립이 있으면 전달
+    let trimmingClip: EditableClip?
+
+    private var displayText: String {
+        if let clip = trimmingClip {
+            // 트리밍 모드: 소수점 두 자리, 앞자리 0 패딩 없이
+            return String(format: "%.2f초", clip.trimmedDuration)
+        } else {
+            // 일반 모드: 소수점 두 자리, 정수부 2자리 0패딩
+            return String(
+               format: "%05.2f / %05.2f",
+               currentTime,
+               totalDuration
+            )
+        }
+    }
+
+    var body: some View {
+        Text(displayText)
+            .font(.caption)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 4)
+    }
+}

--- a/Chalkak/Presentation/ProjectEdit/SubViews/ProjectThumbnailsView.swift
+++ b/Chalkak/Presentation/ProjectEdit/SubViews/ProjectThumbnailsView.swift
@@ -1,0 +1,30 @@
+//
+//  ProjectThumbnailsView.swift
+//  Chalkak
+//
+//  Created by 배현진 on 7/28/25.
+//
+
+import SwiftUI
+
+struct ProjectThumbnailsView: View {
+    let clip: EditableClip
+    let fullWidth: CGFloat
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(clip.thumbnails.indices, id: \.self) { i in
+                Image(uiImage: clip.thumbnails[i])
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(
+                        width: fullWidth / CGFloat(clip.thumbnails.count),
+                        height: 60
+                    )
+                    .clipped()
+            }
+        }
+        .frame(width: fullWidth, height: 60)
+        .contentShape(Rectangle())
+    }
+}

--- a/Chalkak/Presentation/ProjectEdit/SubViews/ProjectTimeBoardView.swift
+++ b/Chalkak/Presentation/ProjectEdit/SubViews/ProjectTimeBoardView.swift
@@ -1,0 +1,44 @@
+//
+//  ProjectTimeBoardView.swift
+//  Chalkak
+//
+//  Created by 배현진 on 7/28/25.
+//
+
+import SwiftUI
+
+struct ProjectTimeBoardView: View {
+    let totalDuration: Double
+    let playHeadPosition: Double
+    let dragOffset: CGFloat
+    let pxPerSecond: CGFloat
+    let rulerHeight: CGFloat
+
+    var body: some View {
+        GeometryReader { geo in
+            let halfWidth = geo.size.width / 2
+            HStack(spacing: 0) {
+                ForEach(0...Int(totalDuration), id: \.self) { sec in
+                    VStack(spacing: 2) {
+                        if sec % 2 == 1 {
+                            Text("\(sec)")
+                                .font(.caption2)
+                        } else {
+                            Circle().frame(width: 2, height: 2)
+                        }
+                        Spacer()
+                    }
+                    .frame(width: pxPerSecond, height: rulerHeight)
+                }
+            }
+            .padding(.horizontal, halfWidth)
+            .offset(x: -CGFloat(playHeadPosition) * pxPerSecond + dragOffset)
+            .frame(
+                width: geo.size.width + CGFloat(totalDuration) * pxPerSecond,
+                height: rulerHeight,
+                alignment: .leading
+            )
+        }
+        .frame(height: rulerHeight)
+    }
+}

--- a/Chalkak/Presentation/ProjectEdit/SubViews/ProjectTimelineView.swift
+++ b/Chalkak/Presentation/ProjectEdit/SubViews/ProjectTimelineView.swift
@@ -1,0 +1,59 @@
+//
+//  ProjectTimelineView.swift
+//  Chalkak
+//
+//  Created by 배현진 on 7/28/25.
+//
+
+import SwiftUI
+
+struct ProjectTimelineView: View {
+    @Binding var clips: [EditableClip]
+    @Binding var isDragging: Bool
+    let playHeadPosition: Double
+    let totalDuration: Double
+    let dragOffset: CGFloat
+
+    let pxPerSecond: CGFloat
+    let clipSpacing: CGFloat
+    let timelineHeight: CGFloat
+
+    let onToggleTrimming: (String) -> Void
+    let onTrimChanged: (String, Double, Double) -> Void
+    let onAddClipTapped: () -> Void
+
+    var body: some View {
+        GeometryReader { geo in
+            let halfWidth = geo.size.width / 2
+            HStack(spacing: clipSpacing) {
+                ForEach(clips) { clip in
+                    ClipTrimmingView(
+                        clip: clip,
+                        isDragging: $isDragging,
+                        onToggleTrimming: { onToggleTrimming(clip.id) },
+                        onTrimChanged:   { s,e in onTrimChanged(clip.id, s, e) }
+                    )
+                }
+                Button(action: onAddClipTapped) {
+                    // TODO: - 버튼 디자인 변경하면서 Stack 제거
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 4)
+                            .stroke(Color.gray, lineWidth: 1)
+                            .frame(width: timelineHeight, height: timelineHeight)
+                        Image(systemName: "plus").font(.title2)
+                    }
+                }
+                .frame(width: timelineHeight, height: timelineHeight)
+            }
+            .padding(.horizontal, halfWidth)
+            .offset(x: -CGFloat(playHeadPosition) * pxPerSecond + dragOffset)
+            .frame(
+                width: geo.size.width + CGFloat(totalDuration) * pxPerSecond,
+                height: timelineHeight,
+                alignment: .leading
+            )
+            .clipped()
+        }
+        .frame(height: timelineHeight)
+    }
+}

--- a/Chalkak/Presentation/ProjectEdit/SubViews/ProjectTrimmingHandle.swift
+++ b/Chalkak/Presentation/ProjectEdit/SubViews/ProjectTrimmingHandle.swift
@@ -1,0 +1,47 @@
+//
+//  ProjectTrimmingHandle.swift
+//  Chalkak
+//
+//  Created by 배현진 on 7/28/25.
+//
+
+import SwiftUI
+
+struct ProjectTrimmingHandle: View {
+    let isStart: Bool
+    let leftW: CGFloat
+    let midW: CGFloat
+    let fullHeight: CGFloat
+    let fullWidth: CGFloat
+    @Binding var isDragging: Bool
+    let onTrimChanged: (Double, Double) -> Void
+    let clip: EditableClip
+
+    var body: some View {
+        let size: CGFloat = 10
+        let xOffset = isStart ? leftW : (leftW + midW - size)
+
+        RoundedRectangle(cornerRadius: 3)
+            .fill(Color.yellow)
+            .frame(width: size, height: fullHeight)
+            .offset(x: xOffset)
+            .gesture(
+                DragGesture()
+                    .onChanged { gesture in
+                        isDragging = true
+                        let ratio = min(max(gesture.location.x / fullWidth, 0), 1)
+                        let time = Double(ratio) * clip.originalDuration
+                        if isStart {
+                            let newStart = min(time, clip.endPoint - 0.1)
+                            onTrimChanged(newStart, clip.endPoint)
+                        } else {
+                            let newEnd = max(time, clip.startPoint + 0.1)
+                            onTrimChanged(clip.startPoint, newEnd)
+                        }
+                    }
+                    .onEnded { _ in
+                        isDragging = false
+                    }
+            )
+    }
+}

--- a/Chalkak/Presentation/ProjectEdit/SubViews/ProjectTrimmingLineView.swift
+++ b/Chalkak/Presentation/ProjectEdit/SubViews/ProjectTrimmingLineView.swift
@@ -1,0 +1,56 @@
+//
+//  ProjectTrimmingLineView.swift
+//  Chalkak
+//
+//  Created by 배현진 on 7/28/25.
+//
+
+import SwiftUI
+
+struct ProjectTrimmingLineView: View {
+    let clip: EditableClip
+    let fullWidth: CGFloat
+    let thumbnailHeight: CGFloat
+    @Binding var isDragging: Bool
+    let onTrimChanged: (Double, Double) -> Void
+
+    var body: some View {
+        let leftW  = CGFloat(clip.startPoint / clip.originalDuration) * fullWidth
+        let midW   = CGFloat(clip.trimmedDuration / clip.originalDuration) * fullWidth
+        let rightW = fullWidth - leftW - midW
+
+        ZStack(alignment: .leading) {
+            HStack(spacing: 0) {
+                Color.black.opacity(0.5).frame(width: leftW)
+                Color.clear.frame(width: midW)
+                Color.black.opacity(0.5).frame(width: rightW)
+            }
+
+            RoundedRectangle(cornerRadius: 4)
+                .stroke(Color.yellow, lineWidth: 2)
+                .frame(width: midW, height: thumbnailHeight)
+                .offset(x: leftW)
+
+            ProjectTrimmingHandle(
+                isStart: true,
+                leftW: leftW,
+                midW: midW,
+                fullHeight: thumbnailHeight,
+                fullWidth: fullWidth,
+                isDragging: $isDragging,
+                onTrimChanged: onTrimChanged,
+                clip: clip
+            )
+            ProjectTrimmingHandle(
+                isStart: false,
+                leftW: leftW,
+                midW: midW,
+                fullHeight: thumbnailHeight,
+                fullWidth: fullWidth,
+                isDragging: $isDragging,
+                onTrimChanged: onTrimChanged,
+                clip: clip
+            )
+        }
+    }
+}

--- a/Chalkak/Presentation/ProjectEdit/SubViews/TrimmingLineSliderView.swift
+++ b/Chalkak/Presentation/ProjectEdit/SubViews/TrimmingLineSliderView.swift
@@ -17,13 +17,14 @@ struct TrimminglineSliderView: View {
     let onSeek: (Double) -> Void
     let onToggleTrimming: (String) -> Void
     let onTrimChanged: (String, Double, Double) -> Void
-    
-    /// 추가된 클로저
     let onAddClipTapped: () -> Void
 
     private let pxPerSecond: CGFloat = 50
     private let clipSpacing: CGFloat = 8
     private let timelineHeight: CGFloat = 60
+
+    // 드래그 오프셋 상태
+    @State private var dragOffset: CGFloat = 0
 
     var body: some View {
         GeometryReader { geo in
@@ -31,7 +32,6 @@ struct TrimminglineSliderView: View {
 
             ZStack(alignment: .leading) {
                 HStack(spacing: clipSpacing) {
-                    // 기존 클립들
                     ForEach(clips) { clip in
                         ClipTrimmingView(
                             clip: clip,
@@ -40,7 +40,6 @@ struct TrimminglineSliderView: View {
                             onTrimChanged:   { s, e in onTrimChanged(clip.id, s, e) }
                         )
                     }
-
                     // + 버튼
                     Button(action: onAddClipTapped) {
                         ZStack {
@@ -54,15 +53,35 @@ struct TrimminglineSliderView: View {
                     .frame(width: timelineHeight, height: timelineHeight)
                 }
                 .padding(.horizontal, halfW)
-                .offset(x: -CGFloat(playHeadPosition) * pxPerSecond)
+                // 드래그 오프셋과 플레이헤드 기반 오프셋 합산
+                .offset(x: -CGFloat(playHeadPosition) * pxPerSecond + dragOffset)
                 .frame(
                     width: geo.size.width + CGFloat(totalDuration) * pxPerSecond,
                     height: timelineHeight,
                     alignment: .leading
                 )
                 .clipped()
+                // 드래그 제스처
+                .gesture(
+                    DragGesture()
+                        .onChanged { g in
+                            isDragging = true
+                            dragOffset = g.translation.width
+                        }
+                        .onEnded { g in
+                            isDragging = false
+                            // 드래그로 바뀐 시간량 계산 (음수 드래그는 앞으로, 양수는 뒤로)
+                            let deltaTime = -Double(g.translation.width / pxPerSecond)
+                            var newTime = playHeadPosition + deltaTime
+                            newTime = min(max(0, newTime), totalDuration)
+                            // 플레이헤드 이동 & 프리뷰 갱신
+                            onSeek(newTime)
+                            // 드래그 오프셋 초기화
+                            dragOffset = 0
+                        }
+                )
 
-                // 플레이헤드(가운데)
+                // 중앙 고정 플레이헤드
                 Rectangle()
                     .fill(Color.red)
                     .frame(width: 2, height: timelineHeight)

--- a/Chalkak/Presentation/ProjectEdit/SubViews/TrimmingLineSliderView.swift
+++ b/Chalkak/Presentation/ProjectEdit/SubViews/TrimmingLineSliderView.swift
@@ -22,72 +22,95 @@ struct TrimminglineSliderView: View {
     private let pxPerSecond: CGFloat = 50
     private let clipSpacing: CGFloat = 8
     private let timelineHeight: CGFloat = 60
+    private let rulerHeight: CGFloat = 20
 
-    // 드래그 오프셋 상태
     @State private var dragOffset: CGFloat = 0
 
     var body: some View {
         GeometryReader { geo in
             let halfW = geo.size.width / 2
-
-            ZStack(alignment: .leading) {
-                HStack(spacing: clipSpacing) {
-                    ForEach(clips) { clip in
-                        ClipTrimmingView(
-                            clip: clip,
-                            isDragging: $isDragging,
-                            onToggleTrimming: { onToggleTrimming(clip.id) },
-                            onTrimChanged:   { s, e in onTrimChanged(clip.id, s, e) }
-                        )
-                    }
-                    // + 버튼
-                    Button(action: onAddClipTapped) {
-                        ZStack {
-                            RoundedRectangle(cornerRadius: 4)
-                                .stroke(Color.gray, lineWidth: 1)
-                                .frame(width: timelineHeight, height: timelineHeight)
-                            Image(systemName: "plus")
-                                .font(.title2)
+            VStack(spacing: 0) {
+                // 1) 시간 눈금 (ruler)
+                HStack(spacing: 0) {
+                    ForEach(0...Int(totalDuration), id: \.self) { sec in
+                        VStack(spacing: 2) {
+                            if sec % 2 == 1 {
+                                Text("\(sec)")
+                                    .font(.caption2)
+                            } else {
+                                Circle()
+                                    .frame(width: 2, height: 2)
+                            }
+                            Spacer()
                         }
+                        .frame(width: pxPerSecond, height: rulerHeight)
                     }
-                    .frame(width: timelineHeight, height: timelineHeight)
                 }
                 .padding(.horizontal, halfW)
-                // 드래그 오프셋과 플레이헤드 기반 오프셋 합산
                 .offset(x: -CGFloat(playHeadPosition) * pxPerSecond + dragOffset)
                 .frame(
                     width: geo.size.width + CGFloat(totalDuration) * pxPerSecond,
-                    height: timelineHeight,
+                    height: rulerHeight,
                     alignment: .leading
                 )
-                .clipped()
-                // 드래그 제스처
-                .gesture(
-                    DragGesture()
-                        .onChanged { g in
-                            isDragging = true
-                            dragOffset = g.translation.width
-                        }
-                        .onEnded { g in
-                            isDragging = false
-                            // 드래그로 바뀐 시간량 계산 (음수 드래그는 앞으로, 양수는 뒤로)
-                            let deltaTime = -Double(g.translation.width / pxPerSecond)
-                            var newTime = playHeadPosition + deltaTime
-                            newTime = min(max(0, newTime), totalDuration)
-                            // 플레이헤드 이동 & 프리뷰 갱신
-                            onSeek(newTime)
-                            // 드래그 오프셋 초기화
-                            dragOffset = 0
-                        }
-                )
 
-                // 중앙 고정 플레이헤드
-                Rectangle()
-                    .fill(Color.red)
-                    .frame(width: 2, height: timelineHeight)
-                    .position(x: halfW, y: timelineHeight/2)
+                // 2) 클립 타임라인 + + 버튼
+                ZStack(alignment: .leading) {
+                    HStack(spacing: clipSpacing) {
+                        ForEach(clips) { clip in
+                            ClipTrimmingView(
+                                clip: clip,
+                                isDragging: $isDragging,
+                                onToggleTrimming: { onToggleTrimming(clip.id) },
+                                onTrimChanged:   { s,e in onTrimChanged(clip.id, s, e) }
+                            )
+                        }
+                        // + 버튼
+                        Button(action: onAddClipTapped) {
+                            ZStack {
+                                RoundedRectangle(cornerRadius: 4)
+                                    .stroke(Color.gray, lineWidth: 1)
+                                    .frame(width: timelineHeight, height: timelineHeight)
+                                Image(systemName: "plus")
+                                    .font(.title2)
+                            }
+                        }
+                        .frame(width: timelineHeight, height: timelineHeight)
+                    }
+                    .padding(.horizontal, halfW)
+                    .offset(x: -CGFloat(playHeadPosition) * pxPerSecond + dragOffset)
+                    .frame(
+                        width: geo.size.width + CGFloat(totalDuration) * pxPerSecond,
+                        height: timelineHeight,
+                        alignment: .leading
+                    )
+                    .clipped()
+                    // 드래그 제스처는 타임라인 전체에 적용
+                    .gesture(
+                        DragGesture()
+                            .onChanged { g in
+                                isDragging = true
+                                dragOffset = g.translation.width
+                            }
+                            .onEnded { g in
+                                isDragging = false
+                                // 이동량 → 시간으로 변환
+                                let deltaTime = -Double(g.translation.width / pxPerSecond)
+                                var newTime = playHeadPosition + deltaTime
+                                newTime = min(max(0, newTime), totalDuration)
+                                onSeek(newTime)
+                                dragOffset = 0
+                            }
+                    )
+
+                    // 3) 중앙 고정 플레이헤드
+                    Rectangle()
+                        .fill(Color.red)
+                        .frame(width: 2, height: timelineHeight + rulerHeight)
+                        .position(x: halfW, y: (timelineHeight + rulerHeight)/2)
+                }
             }
         }
-        .frame(height: timelineHeight)
+        .frame(height: timelineHeight + rulerHeight)
     }
 }

--- a/Chalkak/Presentation/ProjectEdit/SubViews/TrimmingLineSliderView.swift
+++ b/Chalkak/Presentation/ProjectEdit/SubViews/TrimmingLineSliderView.swift
@@ -17,39 +17,52 @@ struct TrimminglineSliderView: View {
     let onSeek: (Double) -> Void
     let onToggleTrimming: (String) -> Void
     let onTrimChanged: (String, Double, Double) -> Void
-
-//    @State private var scrollOffset: CGFloat = 0
+    
+    /// 추가된 클로저
+    let onAddClipTapped: () -> Void
 
     private let pxPerSecond: CGFloat = 50
     private let clipSpacing: CGFloat = 8
     private let timelineHeight: CGFloat = 60
-
 
     var body: some View {
         GeometryReader { geo in
             let halfW = geo.size.width / 2
 
             ZStack(alignment: .leading) {
-                // → HStack 을 패딩 후 offset 으로 좌측으로 밀기
                 HStack(spacing: clipSpacing) {
+                    // 기존 클립들
                     ForEach(clips) { clip in
                         ClipTrimmingView(
                             clip: clip,
                             isDragging: $isDragging,
                             onToggleTrimming: { onToggleTrimming(clip.id) },
-                            onTrimChanged:   { s,e in onTrimChanged(clip.id, s, e) }
+                            onTrimChanged:   { s, e in onTrimChanged(clip.id, s, e) }
                         )
                     }
+
+                    // + 버튼
+                    Button(action: onAddClipTapped) {
+                        ZStack {
+                            RoundedRectangle(cornerRadius: 4)
+                                .stroke(Color.gray, lineWidth: 1)
+                                .frame(width: timelineHeight, height: timelineHeight)
+                            Image(systemName: "plus")
+                                .font(.title2)
+                        }
+                    }
+                    .frame(width: timelineHeight, height: timelineHeight)
                 }
                 .padding(.horizontal, halfW)
-                // 플레이헤드(가운데)에 현재 프레임이 오도록
                 .offset(x: -CGFloat(playHeadPosition) * pxPerSecond)
-                .frame(width: geo.size.width + CGFloat(totalDuration) * pxPerSecond, // content width 크게 잡아두고
-                       height: timelineHeight,
-                       alignment: .leading)
+                .frame(
+                    width: geo.size.width + CGFloat(totalDuration) * pxPerSecond,
+                    height: timelineHeight,
+                    alignment: .leading
+                )
                 .clipped()
 
-                // 중앙 고정 플레이헤드
+                // 플레이헤드(가운데)
                 Rectangle()
                     .fill(Color.red)
                     .frame(width: 2, height: timelineHeight)

--- a/Chalkak/Presentation/ProjectEdit/SubViews/TrimmingLineSliderView.swift
+++ b/Chalkak/Presentation/ProjectEdit/SubViews/TrimmingLineSliderView.swift
@@ -1,0 +1,103 @@
+//
+//  TrimmingLineSliderView.swift
+//  Chalkak
+//
+//  Created by 배현진 on 7/24/25.
+//
+
+import SwiftUI
+
+struct TrimminglineSliderView: View {
+    @Binding var clips: [EditableClip]
+    @Binding var playHeadPosition: Double
+    @Binding var isDragging: Bool
+    let isPlaying: Bool
+    let totalDuration: Double
+
+    let onSeek: (Double) -> Void
+    let onToggleTrimming: (String) -> Void
+    let onTrimChanged: (String, Double, Double) -> Void
+
+    @State private var scrollOffset: CGFloat = 0.0
+    @State private var timelineWidth: CGFloat = 0.0
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            // 시간 표시 (현재 시간 / 전체 길이)
+            HStack {
+                Text(formattedTime(playHeadPosition))
+                    .font(.caption)
+                Spacer()
+                Text(formattedTime(totalDuration))
+                    .font(.caption)
+            }
+
+            // 타임라인 클립 썸네일 + 핸들
+            GeometryReader { geometry in
+                ScrollViewReader { scrollReader in
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 0) {
+                            ForEach(clips) { clip in
+                                ClipTrimmingView(
+                                    clip: clip,
+                                    isTrimming: clip.isTrimming,
+                                    isDragging: $isDragging,
+                                    onToggleTrimming: {
+                                        onToggleTrimming(clip.id)
+                                    },
+                                    onTrimChanged: { newStart, newEnd in
+                                        onTrimChanged(clip.id, newStart, newEnd)
+                                    }
+                                )
+                            }
+                            // dummy ID
+                            Color.clear
+                                .frame(width: 1, height: 1)
+                                .id("scroll-target")
+                        }
+                        .background(GeometryReader {
+                            Color.clear.preference(key: TimelineWidthKey.self, value: $0.size.width)
+                        })
+                        .onPreferenceChange(TimelineWidthKey.self) { width in
+                            timelineWidth = width
+                        }
+                    }
+                    .overlay(alignment: .center) {
+                        Rectangle()
+                            .fill(Color.red)
+                            .frame(width: 2, height: 60)
+                    }
+                    .onChange(of: playHeadPosition) { newTime in
+                        scrollToPlayhead(reader: scrollReader, container: geometry.size)
+                    }
+                }
+            }
+            .frame(height: 80)
+        }
+    }
+
+    // MARK: - 시간 포맷 함수
+    private func formattedTime(_ seconds: Double) -> String {
+        let totalSeconds = Int(seconds)
+        let mins = totalSeconds / 60
+        let secs = totalSeconds % 60
+        return String(format: "%d:%02d", mins, secs)
+    }
+
+    // MARK: - 재생 중 자동 스크롤
+    private func scrollToPlayhead(reader: ScrollViewProxy, container: CGSize) {
+        let relativeX = CGFloat(playHeadPosition / totalDuration) * timelineWidth
+        let scrollX = max(0, relativeX - container.width / 2)
+        withAnimation {
+            reader.scrollTo("playhead-scroll", anchor: .leading)
+        }
+    }
+}
+
+
+private struct TimelineWidthKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #94

## ✨ PR Content
> 작업 내용 설명을 적어주세요.

프로젝트 편집을 위한 기능들을 구현합니다.
- [x] 슬라이드 형태로 트리밍 타임라인 구간 구현하기
- [x] 슬라이드에 각각의 클립 영상 구간 나눠 띄우기
- [x] 각 클립 영상을 선택하면 개별 트리밍 진행하고 프리뷰에 반영하기
- [x] playHead가 재생 시점이 되도록 하기 (가운데 위치)
- [x] 클립 시간 실시간 표기 및 프로젝트 시간 실시간 표기
- [x] 클립 추가 구현하기
- [x] 클립 삭제 구현하기
- [x] 플레이 버튼 구현하기
- [x] 클립 구간 반복 재생

## 📸 Screenshot
> 작업 화면의 스크린샷을 추가해주세요.

|    구현 내용    |    Mini   |   Pro   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "" width ="250"> | <img src = "" width ="250"> |

## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요

- Hiti / 레이아웃 등은 제외하고 기능 구현 진행하였습니다.
기능에서도 조금 PR 단위를 나누려고 했었는데, 개발하다 보니 그렇게 하지 못해서 큰 덩어리 PR이 탄생해버렸습니다.. 😇
리뷰하기 불편하실 수 있을 것 같아 최대한 커밋을 쪼개려고 했으니, 커밋 단위로 확인 해보셔도 좋을 것 같습니다.

- 내보내기 / 저장하기 버튼
해당 버튼과 기능들은 앞서 구현되어 있는 내용들이 있기 때문에 따로 작업하지 않았습니다.
이후에 연결만 하면 될 것 같습니다.

- 현재 조금 더 개선이 필요한 부분
기능 명세를 기준으로 아직 구현되지 않은 부분들이 자잘하게 존재합니다.

1. 네비게이션 로직과 데이터 저장
데이터 저장 (편집 변경사항) 구현은 간단하게 가능하기에 시트 없이 뒤로가기 시점에 굳이 바로 저장해둘 필요는 없을 것 같아 우선은 제외하였습니다. 액션 시트 도입하면서 함께 진행하면 될 것 같다고 생각해 현재는 뒤로가기만 구현되어 있는 상태입니다.

2.  트리밍 후 클립 선택이 해제되었을 때, 전체 타임라인에 트리밍된 부분 보여주지 않기
이 부분은 자연스럽게 처리하기가 잘 안되는것 같아 따로 좀 더 시도해보겠습니다.


## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
