### PR TITLE
💄 [style] 비디오 로딩중 영역 채우기

### DIFF
--- a/Chalkak/Presentation/ClipEdit/SubViews/VideoPreviewView.swift
+++ b/Chalkak/Presentation/ClipEdit/SubViews/VideoPreviewView.swift
@@ -36,7 +36,16 @@ struct VideoPreviewView: View {
                     .aspectRatio(9.0 / 16.0, contentMode: .fit)
                     .clipped()
             } else {
-                Text("영상을 불러오는 중...")
+                //TODO: hifi 나오면 다시 한번 확인
+                // 로딩 중일 때도 동일한 aspectRatio 공간 확보 임시 뷰
+                ZStack {
+                    Rectangle()
+                        .fill(SnappieColor.darkStrong)
+                    Text("영상을 불러오는 중...")
+                        .foregroundColor(SnappieColor.primaryLight)
+                        .font(SnappieFont.style(.kronaLabel1))
+                }
+                .aspectRatio(9.0 / 16.0, contentMode: .fit)
             }
         }
     }


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #126 

## ✨ PR Content
> 작업 내용 설명을 적어주세요.
 비디오 로딩중 영역 채우기
비디오 불러올때 아주 잠시잠깐 보이는 뷰입니다


## 📸 Screenshot
> 작업 화면의 스크린샷을 추가해주세요.
<img width="1179" height="2556" alt="IMG_7872" src="https://github.com/user-attachments/assets/4f258364-9cad-4d05-8649-cb32dacc4399" />



## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요

- 특이 사항 1
- 특이 사항 2

## ✅ Checklist
- [X] Merge 하는 브랜치가 올바른지 확인
- [X] 필요없는 주석, 프린트문 제거했는지 확인
- [X] PR과 관련없는 변경사항 없는지 확인
- [X] 컨벤션 지켰는지 확인
