### PR TITLE
🐛 [fix] 영상 내보내기 할 때 오디오 트랙도 내보내도록 구현

### DIFF
--- a/Chalkak/Core/VideoEditor/VideoMerger.swift
+++ b/Chalkak/Core/VideoEditor/VideoMerger.swift
@@ -111,14 +111,13 @@ struct VideoMerger {
             throw VideoMergerError.videoTrackCreationFailed
         }
         
-        // TODO: 오디오 기능 도입되면 주석 해제(ssol)
         // 3. 오디오 트랙 생성
-//        guard let audioTrack = composition.addMutableTrack(
-//            withMediaType: .audio,
-//            preferredTrackID: Int32(kCMPersistentTrackID_Invalid)
-//        ) else {
-//            throw VideoMergerError.audioTrackCreationFailed
-//        }
+        guard let audioTrack = composition.addMutableTrack(
+            withMediaType: .audio,
+            preferredTrackID: Int32(kCMPersistentTrackID_Invalid)
+        ) else {
+            throw VideoMergerError.audioTrackCreationFailed
+        }
         
         // 4. 각 애셋을 순차적으로 합치기
         for (index, asset) in assets.enumerated() {
@@ -133,16 +132,14 @@ struct VideoMerger {
                 let videoTracks = try await asset.loadTracks(withMediaType: .video)
                 guard !videoTracks.isEmpty else { continue }
                 
-                // TODO: 오디오 기능 도입되면 주석 해제(ssol)
-//            // 오디오 트랙이 있으면 추가
-//            let audioTracks = try await asset.loadTracks(withMediaType: .audio)
-//            guard !audioTracks.isEmpty else { continue }
+            // 오디오 트랙이 있으면 추가
+            let audioTracks = try await asset.loadTracks(withMediaType: .audio)
+            guard !audioTracks.isEmpty else { continue }
                 
                 // 비디오
                 try videoTrack.insertTimeRange(timeRangeToInsert, of: videoTracks[0], at: lastTime)
                 
-                // TODO: 오디오 기능 도입되면 주석 해제(ssol)
-//                try audioTrack.insertTimeRange(timeRangeToInsert, of: audioTracks[0], at: lastTime)
+                try audioTrack.insertTimeRange(timeRangeToInsert, of: audioTracks[0], at: lastTime)
                 
                 lastTime = CMTimeAdd(lastTime, timeRangeToInsert.duration)
                 


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #125

## ✨ PR Content
> 작업 내용 설명을 적어주세요.

영상을 합쳐서 내보내기 할 때 오디오까지 포함한 영상으로 저장되도록 구현했습니다.

## 📸 Screenshot
> 작업 화면의 스크린샷을 추가해주세요.

URL을 넘겨주면 오디오까지 포함한 영상으로 잘 저장이 됩니다!🙂👍

## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요

-처음에는 비디오와 오디오를 함께 구현해두었지만, 당시에는 오디오가 없는 상태였어서 오디오 관련 코드는 주석 처리해두었습니다. 이번에는 해당 주석을 정리하고 제거했습니다.

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
