### PR TITLE
💄 [Style] #131 타이머 카운트 설정시 오버레이 기능 구현

### DIFF
--- a/Chalkak/Presentation/Camera/CameraView.swift
+++ b/Chalkak/Presentation/Camera/CameraView.swift
@@ -16,6 +16,8 @@ struct CameraView: View {
 
     @State private var clipUrl: URL?
     @State private var navigateToEdit = false
+    @State private var feedbackOpacity: Double = 0
+    @State private var fadeOutTask: Task<Void, Never>?
 
     var body: some View {
         ZStack {
@@ -25,18 +27,28 @@ struct CameraView: View {
                 SnappieColor.darkHeavy.edgesIgnoringSafeArea(.all)
             }
 
-            CameraPreviewView(
-                session: viewModel.session,
-                tabToFocus: viewModel.focusAtPoint,
-                onPinchZoom: viewModel.selectZoomScale,
-                currentZoomScale: viewModel.zoomScale,
-                isUsingFrontCamera: viewModel.isUsingFrontCamera,
-                showGrid: $viewModel.isGrid,
-                isTimerRunning: viewModel.isTimerRunning,
-                timerCountdown: viewModel.timerCountdown
-            )
-            .aspectRatio(9 / 16, contentMode: .fit)
-            .clipped()
+            ZStack {
+                CameraPreviewView(
+                    session: viewModel.session,
+                    tabToFocus: viewModel.focusAtPoint,
+                    onPinchZoom: viewModel.selectZoomScale,
+                    currentZoomScale: viewModel.zoomScale,
+                    isUsingFrontCamera: viewModel.isUsingFrontCamera,
+                    showGrid: $viewModel.isGrid,
+                    isTimerRunning: viewModel.isTimerRunning,
+                    timerCountdown: viewModel.timerCountdown
+                )
+                .aspectRatio(9 / 16, contentMode: .fit)
+                .clipped()
+
+                // 타이머 설정 오버레이
+                if viewModel.showTimerFeedback != nil {
+                    Text("\(viewModel.showTimerFeedback!.rawValue)")
+                        .font(SnappieFont.style(.kronaExtra))
+                        .foregroundColor(SnappieColor.labelPrimaryNormal)
+                        .opacity(feedbackOpacity)
+                }
+            }
             .padding(.top, Layout.preViewTopPadding)
             .padding(.horizontal, Layout.preViewHorizontalPadding)
             .frame(maxHeight: .infinity, alignment: .top)
@@ -53,6 +65,30 @@ struct CameraView: View {
 
                 CameraBottomControlView(viewModel: viewModel)
             }.padding(.horizontal, Layout.cameraControlHorizontalPadding)
+        }
+        .onChange(of: viewModel.showTimerFeedback) { _, newValue in
+            fadeOutTask?.cancel()
+
+            if newValue != nil {
+                // 즉시 opacity 1
+                feedbackOpacity = 1
+                fadeOutTask = Task {
+                    do {
+                        // 대기 1초
+                        try await Task.sleep(nanoseconds: 700_000_000)
+
+                        // 태스크가 취소되지 않았다면 페이드아웃
+                        if !Task.isCancelled {
+                            withAnimation(.easeOut(duration: 0.3)) {
+                                // nil 로 하면 fadeout이 적용되지않아서 opacity로 조절
+                                feedbackOpacity = 0
+                            }
+                        }
+                    } catch {
+                        print("Error: \(error)")
+                    }
+                }
+            }
         }
         .onReceive(viewModel.videoSavedPublisher) { url in
             self.clipUrl = url

--- a/Chalkak/Presentation/Camera/CameraView.swift
+++ b/Chalkak/Presentation/Camera/CameraView.swift
@@ -34,9 +34,7 @@ struct CameraView: View {
                     onPinchZoom: viewModel.selectZoomScale,
                     currentZoomScale: viewModel.zoomScale,
                     isUsingFrontCamera: viewModel.isUsingFrontCamera,
-                    showGrid: $viewModel.isGrid,
-                    isTimerRunning: viewModel.isTimerRunning,
-                    timerCountdown: viewModel.timerCountdown
+                    showGrid: $viewModel.isGrid
                 )
                 .aspectRatio(9 / 16, contentMode: .fit)
                 .clipped()
@@ -47,6 +45,15 @@ struct CameraView: View {
                         .font(SnappieFont.style(.kronaExtra))
                         .foregroundColor(SnappieColor.labelPrimaryNormal)
                         .opacity(feedbackOpacity)
+                }
+                
+                // 타이머 카운트다운 오버레이
+                if viewModel.isTimerRunning && viewModel.timerCountdown > 0 {
+                    Text("\(viewModel.timerCountdown)")
+                        .font(SnappieFont.style(.kronaExtra))
+                        .foregroundColor(SnappieColor.labelPrimaryNormal)
+                        .transition(.opacity)
+                        .animation(.easeOut(duration: 0.4), value: viewModel.timerCountdown)
                 }
             }
             .padding(.top, Layout.preViewTopPadding)

--- a/Chalkak/Presentation/Camera/CameraViewModel.swift
+++ b/Chalkak/Presentation/Camera/CameraViewModel.swift
@@ -24,6 +24,8 @@ class CameraViewModel: ObservableObject {
 
     @Published var isTimerRunning = false
     @Published var selectedTimerDuration: TimerOptions = .off
+    @Published var showTimerFeedback: TimerOptions? = nil // 타이머 설정 피드백 표시
+    private var feedbackTimer: Timer? // 타이머 피드백 라벨 1초 유지를 위한 타이머
 
     @Published var showingCameraControl = false
     @Published var torchMode: TorchMode = .off
@@ -133,7 +135,6 @@ class CameraViewModel: ObservableObject {
     }
 
     func toggleTimerOption() {
-        // Cycle through timer options: off -> 3s -> 5s -> 10s -> off
         switch selectedTimerDuration {
         case .off:
             selectedTimerDuration = .three
@@ -143,6 +144,18 @@ class CameraViewModel: ObservableObject {
             selectedTimerDuration = .ten
         case .ten:
             selectedTimerDuration = .off
+        }
+
+        // 설정시 피드백 표시
+        if selectedTimerDuration != .off {
+            feedbackTimer?.invalidate()
+
+            showTimerFeedback = selectedTimerDuration
+
+            // 1초 디졸브를 위한 타이머(타이머가 몇초 설정되었음을 알려주기 위한 숫자라벨)
+            feedbackTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { [weak self] _ in
+                self?.showTimerFeedback = nil
+            }
         }
     }
 

--- a/Chalkak/Presentation/Camera/CameraViewModel.swift
+++ b/Chalkak/Presentation/Camera/CameraViewModel.swift
@@ -61,17 +61,6 @@ class CameraViewModel: ObservableObject {
     var minZoomScale: CGFloat { 0.5 }
     var maxZoomScale: CGFloat { 6.0 }
 
-    // 현재 카메라 타입 표시
-    var currentCameraTypeSymbol: String {
-        if zoomScale < 1.0 {
-            return "0.5×" // 울트라 와이드
-        } else if zoomScale <= 2.0 {
-            return "1×" // 와이드
-        } else {
-            return "2×" // 망원
-        }
-    }
-
     private var timer: Timer?
     private var timerCountdownTimer: Timer?
     private var dataCollectionTimer: Timer?
@@ -85,8 +74,6 @@ class CameraViewModel: ObservableObject {
         let seconds = recordingTime % 60
         return String(format: "%02d:%02d", minutes, seconds)
     }
-
-    // MARK: - init
 
     init() {
         model = CameraManager()

--- a/Chalkak/Presentation/Camera/Preview/CameraPreviewView.swift
+++ b/Chalkak/Presentation/Camera/Preview/CameraPreviewView.swift
@@ -245,6 +245,7 @@ struct CameraPreviewView: UIViewRepresentable {
                     newLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
                 ])
                 
+                // TODO: 애니메이션 변환 필요
                 // 디졸브애니메이션
                 UIView.animate(withDuration: 0.4, animations: {
                     existingLabel.alpha = 0

--- a/Chalkak/Presentation/Camera/Preview/CameraPreviewView.swift
+++ b/Chalkak/Presentation/Camera/Preview/CameraPreviewView.swift
@@ -14,12 +14,9 @@ struct CameraPreviewView: UIViewRepresentable {
     let currentZoomScale: CGFloat
     let isUsingFrontCamera: Bool
     @Binding var showGrid: Bool
-    let isTimerRunning: Bool
-    let timerCountdown: Int
     
     class VideoPreviewView: UIView {
         var gridLayer: CAShapeLayer?
-        var countdownLabel: UILabel?
         var handleFocus: ((CGPoint) -> Void)?
         var handlePinchZoom: ((CGFloat) -> Void)?
         var isUsingFrontCamera: Bool = false
@@ -218,61 +215,6 @@ struct CameraPreviewView: UIViewRepresentable {
             gridLayer?.removeFromSuperlayer()
             gridLayer = nil
         }
-        
-        func showCountdown(_ countdown: Int) {
-            let timerText = "\(countdown)"
-            
-            /// 카운트다운에 필요한 라벨 생성함수
-            func createLabel(text: String, alpha: CGFloat = 1.0) -> UILabel {
-                let label = UILabel()
-                label.text = text
-                label.textColor = UIColor(SnappieColor.labelPrimaryNormal)
-                label.font = UIFont(name: "KronaOne-Regular", size: 164)
-                label.textAlignment = .center
-                label.translatesAutoresizingMaskIntoConstraints = false
-                label.alpha = alpha
-                return label
-            }
-            
-            // 이미 카운트다운중일때 숫자교체 디졸브
-            if let existingLabel = countdownLabel, existingLabel.text != timerText {
-                let newLabel = createLabel(text: timerText, alpha: 0)
-                addSubview(newLabel)
-                
-                // 카메라 프레임기준 중앙 배치
-                NSLayoutConstraint.activate([
-                    newLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
-                    newLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
-                ])
-                
-                // TODO: 애니메이션 변환 필요
-                // 디졸브애니메이션
-                UIView.animate(withDuration: 0.4, animations: {
-                    existingLabel.alpha = 0
-                    newLabel.alpha = 1
-                }) { _ in
-                    existingLabel.removeFromSuperview()
-                }
-                
-                countdownLabel = newLabel
-            } else if countdownLabel == nil {
-                // 처음 생성하는 경우
-                let label = createLabel(text: timerText)
-                addSubview(label)
-                
-                NSLayoutConstraint.activate([
-                    label.centerXAnchor.constraint(equalTo: centerXAnchor),
-                    label.centerYAnchor.constraint(equalTo: centerYAnchor)
-                ])
-                
-                countdownLabel = label
-            }
-        }
-        
-        func hideCountdown() {
-            countdownLabel?.removeFromSuperview()
-            countdownLabel = nil
-        }
     }
    
     func makeUIView(context: Context) -> VideoPreviewView {
@@ -293,13 +235,6 @@ struct CameraPreviewView: UIViewRepresentable {
     
     func updateUIView(_ uiView: VideoPreviewView, context: Context) {
         showGrid ? uiView.showGrid() : uiView.hideGrid()
-        
-        // 카운트다운
-        if isTimerRunning, timerCountdown > 0 {
-            uiView.showCountdown(timerCountdown)
-        } else {
-            uiView.hideCountdown()
-        }
         
         // 외부에서 줌 스케일이 변경되었을 때 동기화
         uiView.updateInitialZoomScale(currentZoomScale)


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #131 

## ✨ PR Content
- 카메라 설정시 1초간 오버레이 후 디졸브 되는 기능을 추가했습니다 ! 
- CameraPreview에 있던 기존 타이머 카운트다운을 CameraView로 이동하였습니다 ! 


## 📸 Screenshot
<img width=250  alt="image" src="https://github.com/user-attachments/assets/843e9750-4f89-4dd9-bb94-4ae2b173a9ed" />

## 📍 PR Point 
- 특이 사항 1
- 타이머 카운트다운시 초세기가 생각보다 역동적이지 않은데, 초를 줄여도 비슷하네요..! 다른 방안을 한번 고민해보겠습니다 ! 


## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
