### PR TITLE
💄 [Style] #121  수평선 가이드라인 개선

### DIFF
--- a/Chalkak/Presentation/Camera/SubViews/HorizontalLevelIndicator.swift
+++ b/Chalkak/Presentation/Camera/SubViews/HorizontalLevelIndicator.swift
@@ -45,40 +45,24 @@ struct HorizontalLevelIndicatorView: View {
 
     var body: some View {
         ZStack {
-            // 고정 기준선들 (회전 X )
+            /// 양옆 고정 기준선들 (회전하지 않음)
+            ///  양옆 고정 20px + 중앙 공백 121
             HStack(spacing: 0) {
-                // 왼쪽고정선 20px
-                Rectangle()
-                    .frame(width: 20, height: 1)
-                    .foregroundColor(lineColor)
-                // 일직선영역 공백 비워두기
-                Color.clear
-                    .frame(width: 121, height: 1)
-                // 오른쪽고정선 20px
-                Rectangle()
-                    .frame(width: 20, height: 1)
-                    .foregroundColor(lineColor)
+                levelLine(width: 20) // 왼쪽 고정선
+                spacer(width: 121) // 일직선 시소 영역(공백)
+                levelLine(width: 20) // 오른쪽 고정선
             }
-
+            /// 회전하는 시소 부분
+            /// 양옆 공백 20 px + 중앙 일직선 121
             HStack(spacing: 0) {
-                Color.clear
-                    .frame(width: 20, height: 1)
-                // 일직선(왼쪽 48px + 중간부(공백 25px) + 오른쪽 48px)
+                spacer(width: 20)
                 HStack(spacing: 0) {
-                    Rectangle()
-                        .frame(width: 48, height: 1)
-                        .foregroundColor(lineColor)
-
-                    Color.clear
-                        .frame(width: 25, height: 1)
-
-                    Rectangle()
-                        .frame(width: 48, height: 1)
-                        .foregroundColor(lineColor)
+                    levelLine(width: 48)
+                    spacer(width: 25) // 중앙 선 사이 공백
+                    levelLine(width: 48)
                 }
                 .rotationEffect(.degrees(tiltAngle), anchor: .center)
-                Color.clear
-                    .frame(width: 20, height: 1)
+                spacer(width: 20)
             }
         }
         .frame(height: 50)
@@ -102,6 +86,18 @@ struct HorizontalLevelIndicatorView: View {
             horizontalTimer?.invalidate()
             horizontalTimer = nil
         }
+    }
+
+    /// 수평선
+    private func levelLine(width: CGFloat) -> some View {
+        Rectangle()
+            .frame(width: width, height: 1)
+            .foregroundColor(lineColor)
+    }
+
+    /// 투명 여백
+    private func spacer(width: CGFloat) -> some View {
+        Color.clear.frame(width: width, height: 1)
     }
 
     /// 수평일때 or 각도가15도이상 벗어났을때  dissove처리를 위한 메소드


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #121 

## ✨ PR Content
- 수평선의 가이드라인을 각각 다른 선이 아닌, 일직선 형태로 개선했습니다.
- 수평선에 보정값을 추가하여, 수평값으로 판단할시 각도를 0.0으로 적용되게하였습니다. tilt의 보정과 일치하게끔 수정하였습니다. 


## 📸 Screenshot
https://github.com/user-attachments/assets/0e851158-f339-4d20-935c-9d6641f7e5eb


## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요
- 특이 사항 1
일직선으로 구현하기위해 각각  중첩된`HStack`으로 구현되어있던 선들을 `Zstack`으로 묶은다음,  양옆 20px짜리 기준선, 가운데 일직선 + 가운데 공백 으로 각각 HStack을 활용해서 맞춰주었는데, 더 깔금하거나 좋은 메소드?가 있다면 말씀해주신다면 바로 수정하겠습니다...! 


## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
