### PR TITLE
✨ [Feat] 줌 인디케이터 인터렉션 개선

### DIFF
--- a/Chalkak.xcodeproj/project.pbxproj
+++ b/Chalkak.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		B647886A2E33A34F0091A067 /* ZoomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B64788692E33A34F0091A067 /* ZoomButton.swift */; };
 		B647886C2E33A5A50091A067 /* CameraZoomControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B647886B2E33A5A00091A067 /* CameraZoomControlView.swift */; };
 		B68307542E327F9400517979 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		B6A592622E37B49000D3DF6A /* ZoomButtonGestureModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A592612E37B49000D3DF6A /* ZoomButtonGestureModifier.swift */; };
 		B6AB62AE2E2E8DBE00207590 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		C5886D302E371D9B000566C5 /* OverlaySkeletonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5886D2E2E371D9B000566C5 /* OverlaySkeletonView.swift */; };
 		C5886D312E371D9B000566C5 /* OverlayDisplayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5886D2D2E371D9B000566C5 /* OverlayDisplayView.swift */; };
@@ -215,6 +216,7 @@
 		B64788692E33A34F0091A067 /* ZoomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomButton.swift; sourceTree = "<group>"; };
 		B647886B2E33A5A00091A067 /* CameraZoomControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraZoomControlView.swift; sourceTree = "<group>"; };
 		B655A8672E26A4EE0060E2C0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		B6A592612E37B49000D3DF6A /* ZoomButtonGestureModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomButtonGestureModifier.swift; sourceTree = "<group>"; };
 		C5886D2D2E371D9B000566C5 /* OverlayDisplayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayDisplayView.swift; sourceTree = "<group>"; };
 		C5886D2E2E371D9B000566C5 /* OverlaySkeletonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlaySkeletonView.swift; sourceTree = "<group>"; };
 		C5C12E9F2E2FED5500C4DC6D /* ButtonStyler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonStyler.swift; sourceTree = "<group>"; };
@@ -451,6 +453,7 @@
 			isa = PBXGroup;
 			children = (
 				B647886B2E33A5A00091A067 /* CameraZoomControlView.swift */,
+				B6A592612E37B49000D3DF6A /* ZoomButtonGestureModifier.swift */,
 				B64788672E3324350091A067 /* HorizontalLevelIndicator.swift */,
 				B64788632E3323C10091A067 /* RecordButton.swift */,
 				993A1F2D2E267E0C0059B70A /* CameraBaseFeatureSelectView.swift */,
@@ -954,6 +957,7 @@
 				993A1F702E267E0C0059B70A /* ShootState.swift in Sources */,
 				993A1F722E267E0C0059B70A /* OverlayView.swift in Sources */,
 				992EE8132E36CF070079AFBF /* ProjectTrimmingHandle.swift in Sources */,
+				B6A592622E37B49000D3DF6A /* ZoomButtonGestureModifier.swift in Sources */,
 				993A1F732E267E0C0059B70A /* OverlayViewModel.swift in Sources */,
 				992EE80F2E36CE690079AFBF /* ProjectThumbnailsView.swift in Sources */,
 				B647886A2E33A34F0091A067 /* ZoomButton.swift in Sources */,

--- a/Chalkak/Presentation/Camera/SubViews/CameraRecordView.swift
+++ b/Chalkak/Presentation/Camera/SubViews/CameraRecordView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct CameraRecordView: View {
     @ObservedObject var viewModel: CameraViewModel
     @EnvironmentObject private var coordinator: Coordinator
-    
+
     var body: some View {
         HStack(spacing: 0) {
             Button(action: {
@@ -19,13 +19,13 @@ struct CameraRecordView: View {
                 ZStack {
                     // TODO: - 이미지 표시 위한 분기 처리 필요
                     Color.gray
-                        .frame(width: 70, height: 70)
+                        .frame(width: Layout.recordButtonSize.width, height: Layout.recordButtonSize.height)
                 }
                 .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
             }
-            
+
             Spacer()
-            
+
             RecordButton(
                 isRecording: viewModel.isRecording,
                 isTimerRunning: viewModel.isTimerRunning
@@ -36,15 +36,21 @@ struct CameraRecordView: View {
                     viewModel.startVideoRecording()
                 }
             }
-            
+
             Spacer()
-            
+
             SnappieButton(.solidSecondary(contentType: .icon(.conversion), size: .medium, isOutlined: false)
             ) {
                 viewModel.changeCamera()
             }
         }
-        .padding(.bottom, 20)
-        .padding(.horizontal, 20)
+        .padding(.bottom, Layout.recordButtonBottomPadding)
+        .padding(.horizontal, Layout.recordButtonHorizontalPadding)
     }
+}
+
+private extension Layout {
+    static let recordButtonSize = CGSize(width: 70, height: 70)
+    static let recordButtonBottomPadding: CGFloat = 20
+    static let recordButtonHorizontalPadding: CGFloat = 20
 }

--- a/Chalkak/Presentation/Camera/SubViews/CameraZoomControlView.swift
+++ b/Chalkak/Presentation/Camera/SubViews/CameraZoomControlView.swift
@@ -20,6 +20,7 @@ private struct ZoomRange {
 
 struct CameraZoomControlView: View {
     @ObservedObject var viewModel: CameraViewModel
+    @State private var longPressStarted = false
 
     // 줌 활성범위
     private let zoomRanges = [
@@ -28,31 +29,21 @@ struct CameraZoomControlView: View {
         ZoomRange(label: "2", min: 2.0, max: .infinity, activeWidth: 60)
     ]
 
+    // 줌 버튼 기본 설정값
+    private let zoomPresets: [CGFloat] = [0.5, 1.0, 2.0]
+
     var body: some View {
         VStack(spacing: 8) {
             // 줌 인디케이터
             HStack(spacing: 8) {
-                ForEach(zoomRanges, id: \.label) { range in
-                    ZoomButton(
-                        text: range.isActive(viewModel.zoomScale) ?
-                            String(format: "%.1fx", viewModel.zoomScale) : range.label,
-                        isActive: range.isActive(viewModel.zoomScale),
-                        width: range.isActive(viewModel.zoomScale) ? range.activeWidth : 32
-                    )
+                ForEach(Array(zoomRanges.enumerated()), id: \.element.label) { index, range in
+                    createZoomButton(for: range, at: index)
                 }
             }
             .padding(.all, 8)
             .background(SnappieColor.darkHeavy.opacity(0.3))
             .clipShape(Capsule())
             .offset(y: viewModel.showingZoomControl ? -10 : 0) // 인디케이터 상승 인터렉션
-            // 롱프레스 줌 슬라이더 적용
-            .onLongPressGesture(minimumDuration: 0.5) {
-                if !viewModel.isTimerRunning {
-                    withAnimation(.easeInOut(duration: 0.3)) {
-                        viewModel.toggleZoomControl()
-                    }
-                }
-            }
 
             // 인디케이터 하단 줌 슬라이더
             if viewModel.showingZoomControl && !viewModel.isTimerRunning {
@@ -70,5 +61,49 @@ struct CameraZoomControlView: View {
             }
         }
         .animation(.easeInOut(duration: 0.3), value: viewModel.showingZoomControl)
+    }
+    
+    // 복잡한 제스처 로직을 별도 함수로 분리
+    @ViewBuilder
+    private func createZoomButton(for range: ZoomRange, at index: Int) -> some View {
+        let isActive = range.isActive(viewModel.zoomScale)
+        let buttonText = isActive ? String(format: "%.1fx", viewModel.zoomScale) : range.label
+        let buttonWidth: CGFloat = isActive ? range.activeWidth : 32
+        
+        ZoomButton(
+            text: buttonText,
+            isActive: isActive,
+            width: buttonWidth
+        )
+        .onTapGesture {
+            handleTapGesture(for: range, at: index)
+        }
+        .onLongPressGesture(minimumDuration: 0.5) {
+            handleLongPressGesture()
+        }
+    }
+    
+    // 탭 제스처 처리
+    private func handleTapGesture(for range: ZoomRange, at index: Int) {
+        let isButtonActive = range.isActive(viewModel.zoomScale)
+        // 슬라이더가 열려있어도 버튼을 탭할 수 있도록 수정
+        // 타이머가 실행 중이 아니고, 현재 활성화된 버튼이 아닌 경우에만 탭 가능
+        let canTap = !isButtonActive && !viewModel.isTimerRunning
+        
+        if canTap {
+            let targetZoom = zoomPresets[index]
+            withAnimation(.easeInOut(duration: 0.3)) {
+                viewModel.selectZoomScale(targetZoom)
+            }
+        }
+    }
+    
+    // 롱프레스 제스처 처리
+    private func handleLongPressGesture() {
+        if !viewModel.isTimerRunning {
+            withAnimation(.easeInOut(duration: 0.3)) {
+                viewModel.toggleZoomControl()
+            }
+        }
     }
 }

--- a/Chalkak/Presentation/Camera/SubViews/CameraZoomControlView.swift
+++ b/Chalkak/Presentation/Camera/SubViews/CameraZoomControlView.swift
@@ -19,15 +19,15 @@ struct CameraZoomControlView: View {
     ]
 
     private var zoomIndicator: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: Layout.zoomIndicatorSpacing) {
             ForEach(Array(zoomRanges.enumerated()), id: \.element.label) { index, range in
                 zoomButton(for: range, at: index)
             }
         }
-        .padding(.all, 8)
-        .background(SnappieColor.darkHeavy.opacity(0.3))
+        .padding(.all, Layout.zoomIndicatorPadding)
+        .background(SnappieColor.darkHeavy.opacity(Layout.zoomIndicatorBackgroundOpacity))
         .clipShape(Capsule())
-        .offset(y: viewModel.showingZoomControl ? -10 : 0)
+        .offset(y: viewModel.showingZoomControl ? Layout.zoomIndicatorOffset : 0)
     }
 
     private var zoomSliderView: some View {
@@ -37,19 +37,8 @@ struct CameraZoomControlView: View {
             maxZoom: viewModel.maxZoomScale,
             onValueChanged: viewModel.selectZoomScale
         )
-        .frame(width: 320, height: 40)
+        .frame(width: Layout.zoomSliderWidth, height: Layout.zoomSliderHeight)
         .transition(.move(edge: .top).combined(with: .opacity))
-    }
-
-    var body: some View {
-        VStack(spacing: 8) {
-            zoomIndicator
-
-            if viewModel.showingZoomControl && !viewModel.isTimerRunning {
-                zoomSliderView
-            }
-        }
-        .animation(.easeInOut(duration: 0.3), value: viewModel.showingZoomControl)
     }
 
     private func zoomButton(for range: ZoomRange, at index: Int) -> some View {
@@ -70,7 +59,7 @@ struct CameraZoomControlView: View {
         guard !viewModel.isTimerRunning,
               !range.isActive(viewModel.zoomScale) else { return }
 
-        withAnimation(.easeInOut(duration: 0.3)) {
+        withAnimation(.easeInOut(duration: Layout.animationDuration)) {
             viewModel.selectZoomScale(range.preset)
         }
     }
@@ -78,10 +67,33 @@ struct CameraZoomControlView: View {
     private func handleLongPressGesture() {
         guard !viewModel.isTimerRunning else { return }
 
-        withAnimation(.easeInOut(duration: 0.3)) {
+        withAnimation(.easeInOut(duration: Layout.animationDuration)) {
             viewModel.toggleZoomControl()
         }
     }
+
+    var body: some View {
+        VStack(spacing: 8) {
+            zoomIndicator
+
+            if viewModel.showingZoomControl && !viewModel.isTimerRunning {
+                zoomSliderView
+            }
+        }
+        .animation(.easeInOut(duration: Layout.animationDuration), value: viewModel.showingZoomControl)
+        .padding(.bottom, Layout.zoomControlBottomPadding)
+    }
+}
+
+private extension Layout {
+    static let zoomControlBottomPadding: CGFloat = 13
+    static let animationDuration: CGFloat = 0.3
+    static let zoomIndicatorSpacing: CGFloat = 8
+    static let zoomIndicatorPadding: CGFloat = 8
+    static let zoomIndicatorBackgroundOpacity: CGFloat = 0.3
+    static let zoomIndicatorOffset: CGFloat = -8
+    static let zoomSliderWidth: CGFloat = 349
+    static let zoomSliderHeight: CGFloat = 48
 }
 
 /// 줌 범위 설정

--- a/Chalkak/Presentation/Camera/SubViews/CameraZoomControlView.swift
+++ b/Chalkak/Presentation/Camera/SubViews/CameraZoomControlView.swift
@@ -7,103 +7,100 @@
 
 import SwiftUI
 
-private struct ZoomRange {
-    let label: String
-    let min: CGFloat
-    let max: CGFloat
-    let activeWidth: CGFloat
-
-    func isActive(_ currentZoom: CGFloat) -> Bool {
-        return currentZoom >= min && currentZoom < max
-    }
-}
-
 struct CameraZoomControlView: View {
     @ObservedObject var viewModel: CameraViewModel
     @State private var longPressStarted = false
 
     // 줌 활성범위
     private let zoomRanges = [
-        ZoomRange(label: ".5", min: 0.0, max: 0.95, activeWidth: 50),
-        ZoomRange(label: "1", min: 0.95, max: 1.9, activeWidth: 60),
-        ZoomRange(label: "2", min: 2.0, max: .infinity, activeWidth: 60)
+        ZoomRange(label: ".5", min: 0.0, max: 0.95, preset: 0.5),
+        ZoomRange(label: "1", min: 0.95, max: 1.9, preset: 1.0),
+        ZoomRange(label: "2", min: 2.0, max: .infinity, preset: 2.0)
     ]
 
-    // 줌 버튼 기본 설정값
-    private let zoomPresets: [CGFloat] = [0.5, 1.0, 2.0]
+    private var zoomIndicator: some View {
+        HStack(spacing: 8) {
+            ForEach(Array(zoomRanges.enumerated()), id: \.element.label) { index, range in
+                zoomButton(for: range, at: index)
+            }
+        }
+        .padding(.all, 8)
+        .background(SnappieColor.darkHeavy.opacity(0.3))
+        .clipShape(Capsule())
+        .offset(y: viewModel.showingZoomControl ? -10 : 0)
+    }
+
+    private var zoomSliderView: some View {
+        ZoomSlider(
+            zoomScale: viewModel.zoomScale,
+            minZoom: viewModel.minZoomScale,
+            maxZoom: viewModel.maxZoomScale,
+            onValueChanged: viewModel.selectZoomScale
+        )
+        .frame(width: 320, height: 40)
+        .transition(.move(edge: .top).combined(with: .opacity))
+    }
 
     var body: some View {
         VStack(spacing: 8) {
-            // 줌 인디케이터
-            HStack(spacing: 8) {
-                ForEach(Array(zoomRanges.enumerated()), id: \.element.label) { index, range in
-                    createZoomButton(for: range, at: index)
-                }
-            }
-            .padding(.all, 8)
-            .background(SnappieColor.darkHeavy.opacity(0.3))
-            .clipShape(Capsule())
-            .offset(y: viewModel.showingZoomControl ? -10 : 0) // 인디케이터 상승 인터렉션
+            zoomIndicator
 
-            // 인디케이터 하단 줌 슬라이더
             if viewModel.showingZoomControl && !viewModel.isTimerRunning {
-                ZoomSlider(
-                    zoomScale: viewModel.zoomScale,
-                    minZoom: viewModel.minZoomScale,
-                    maxZoom: viewModel.maxZoomScale,
-                    onValueChanged: { newValue in
-                        viewModel.selectZoomScale(newValue)
-                    }
-                )
-                // TODO: width 고정값 수정
-                .frame(width: 320, height: 40)
-                .transition(.move(edge: .top).combined(with: .opacity))
+                zoomSliderView
             }
         }
         .animation(.easeInOut(duration: 0.3), value: viewModel.showingZoomControl)
     }
-    
-    // 복잡한 제스처 로직을 별도 함수로 분리
-    @ViewBuilder
-    private func createZoomButton(for range: ZoomRange, at index: Int) -> some View {
-        let isActive = range.isActive(viewModel.zoomScale)
-        let buttonText = isActive ? String(format: "%.1fx", viewModel.zoomScale) : range.label
-        let buttonWidth: CGFloat = isActive ? range.activeWidth : 32
-        
-        ZoomButton(
-            text: buttonText,
-            isActive: isActive,
-            width: buttonWidth
+
+    private func zoomButton(for range: ZoomRange, at index: Int) -> some View {
+        let config = range.buttonConfiguration(for: viewModel.zoomScale)
+
+        return ZoomButton(
+            text: config.text,
+            isActive: config.isActive,
+            width: config.width
         )
-        .onTapGesture {
-            handleTapGesture(for: range, at: index)
-        }
-        .onLongPressGesture(minimumDuration: 0.5) {
-            handleLongPressGesture()
+        .zoomButtonGestures(
+            onTap: { handleTapGesture(for: range) },
+            onLongPress: handleLongPressGesture
+        )
+    }
+
+    private func handleTapGesture(for range: ZoomRange) {
+        guard !viewModel.isTimerRunning,
+              !range.isActive(viewModel.zoomScale) else { return }
+
+        withAnimation(.easeInOut(duration: 0.3)) {
+            viewModel.selectZoomScale(range.preset)
         }
     }
-    
-    // 탭 제스처 처리
-    private func handleTapGesture(for range: ZoomRange, at index: Int) {
-        let isButtonActive = range.isActive(viewModel.zoomScale)
-        // 슬라이더가 열려있어도 버튼을 탭할 수 있도록 수정
-        // 타이머가 실행 중이 아니고, 현재 활성화된 버튼이 아닌 경우에만 탭 가능
-        let canTap = !isButtonActive && !viewModel.isTimerRunning
-        
-        if canTap {
-            let targetZoom = zoomPresets[index]
-            withAnimation(.easeInOut(duration: 0.3)) {
-                viewModel.selectZoomScale(targetZoom)
-            }
-        }
-    }
-    
-    // 롱프레스 제스처 처리
+
     private func handleLongPressGesture() {
-        if !viewModel.isTimerRunning {
-            withAnimation(.easeInOut(duration: 0.3)) {
-                viewModel.toggleZoomControl()
-            }
+        guard !viewModel.isTimerRunning else { return }
+
+        withAnimation(.easeInOut(duration: 0.3)) {
+            viewModel.toggleZoomControl()
         }
+    }
+}
+
+/// 줌 범위 설정
+/// 라벨(.5,1,2 고정텍스트), 최소값~최대값(각각 인디케이터들이 활성화되는 줌 범위), 활성 너비, 기본값 설정
+private struct ZoomRange {
+    let label: String
+    let min: CGFloat
+    let max: CGFloat
+    let activeWidth: CGFloat = 60
+    let preset: CGFloat
+
+    func isActive(_ currentZoom: CGFloat) -> Bool {
+        return currentZoom >= min && currentZoom < max
+    }
+
+    func buttonConfiguration(for currentZoom: CGFloat) -> (text: String, width: CGFloat, isActive: Bool) {
+        let isActive = isActive(currentZoom)
+        let text = isActive ? String(format: "%.1fx", currentZoom) : label
+        let width = isActive ? activeWidth : 32
+        return (text, width, isActive)
     }
 }

--- a/Chalkak/Presentation/Camera/SubViews/ZoomButtonGestureModifier.swift
+++ b/Chalkak/Presentation/Camera/SubViews/ZoomButtonGestureModifier.swift
@@ -1,0 +1,43 @@
+//
+//  ZoomButtonGestureModifier.swift
+//  Chalkak
+//
+//  Created by 정종문 on 7/28/25.
+//
+
+import SwiftUI
+
+/// 줌 버튼의 탭과 롱프레스 제스처를 처리 
+/// 탭은 줌 인디케이터로 기본값이동 
+/// 롱프레스는 줌 슬라이더 소환 
+struct ZoomButtonGestureModifier: ViewModifier {
+    let onTap: () -> Void
+    let onLongPress: () -> Void
+
+    /// 뷰에 탭과 롱프레스 제스처를 적용
+    func body(content: Content) -> some View {
+        content
+            .onTapGesture(perform: onTap)
+            .onLongPressGesture(minimumDuration: 0.5, perform: onLongPress)
+    }
+}
+
+/// 사용예시
+// struct ContentView: View {
+//     var body: some View {
+//         Text("Hello, World!")
+//             .zoomButtonGestures(onTap: {
+//                 print("Tap")
+//             }, onLongPress: {
+//                 print("Long Press")
+//             })
+//     }
+// }
+extension View {
+    func zoomButtonGestures(
+        onTap: @escaping () -> Void,
+        onLongPress: @escaping () -> Void
+    ) -> some View {
+        modifier(ZoomButtonGestureModifier(onTap: onTap, onLongPress: onLongPress))
+    }
+}

--- a/Chalkak/Presentation/Camera/SubViews/ZoomSlider.swift
+++ b/Chalkak/Presentation/Camera/SubViews/ZoomSlider.swift
@@ -21,6 +21,7 @@ struct ZoomSlider: View {
             ZStack {
                 Capsule()
                     .fill(SnappieColor.containerFillNormal)
+                    .opacity(0.6)
                     .frame(height: 50)
                 
                 ZoomSliderLines(geometry: geometry)


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #136 

## ✨ PR Content
- 줌 인디케이터의 비활성화된 인디케이터 버튼 터치시 해당 줌값으로 설정되게 인터렉션을 추가하였습니다.
- 줌 인디케이터와 줌 슬라이더의 위치가 카메라 preview밖을 벗어나던 오류를 수정하였습니다.
- 줌 슬라이더의 색감이 Hi-Fi와 일치하게 수정하였습니다.
- 

## 📸 Screenshot

<img width="211" height="70" alt="image" src="https://github.com/user-attachments/assets/b9bbd332-16fd-4bce-953e-4079c66e090f" />

## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요
제스처 모디파이어 순서를 tap -> longpress 했을때는 괜찮지만, 그 반대의 경우에는 제스처 충돌이 발생하더라구요..! 시간 나면 이부분을 위키에 작성해보겠습니다..! 


## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
