### PR TITLE
✨ [Feat] #142 Alert기반 공통 컴포넌트 제작

### DIFF
--- a/Chalkak/Common/DesignSystem/Alert/CommonAlert.swift
+++ b/Chalkak/Common/DesignSystem/Alert/CommonAlert.swift
@@ -4,22 +4,8 @@
 //
 //  Created by finn on 7/29/25.
 //
+
 import SwiftUI
-
-/*
-사용 예시
-@State private var showAlert = false
-
-// 취소 액션 생략 dismiss 효과
-.alert(.deleteProject, isPresented: $showAlert) {
-    deleteProject()
-}
-
-// 취소 액션 처리
-.alert(.deleteProject, isPresented: $showAlert, 
-       cancelAction: { print("취소됨") },
-       confirmAction: { deleteProject() })
-*/
 
 /// 공통 Alert 타입 정의
 enum AlertType {
@@ -29,7 +15,7 @@ enum AlertType {
     case retakeCurrentVideo
     case endShooting
     case exitWhileRecording
-    
+
     var title: String {
         switch self {
         case .deleteProject: return "프로젝트를 삭제하시겠습니까?"
@@ -40,7 +26,7 @@ enum AlertType {
         case .exitWhileRecording: return "다시 찍으시겠어요?"
         }
     }
-    
+
     var message: String {
         switch self {
         case .deleteProject: return "프로젝트와 클립이 모두 삭제됩니다."
@@ -51,7 +37,7 @@ enum AlertType {
         case .exitWhileRecording: return "지금 나가면 방금 찍은 영상이 지워져요."
         }
     }
-    
+
     var confirmText: String {
         switch self {
         case .deleteProject: return "삭제"
@@ -64,6 +50,20 @@ enum AlertType {
     }
 }
 
+/*
+ 사용 예시
+ @State private var showAlert = false
+
+ // 취소 액션 생략 dismiss 효과
+ .alert(.deleteProject, isPresented: $showAlert) {
+     deleteProject()
+ }
+
+ // 취소 액션 처리
+ .alert(.deleteProject, isPresented: $showAlert,
+        cancelAction: { print("취소됨") },
+        confirmAction: { deleteProject() })
+ */
 
 extension View {
     func alert(
@@ -82,4 +82,3 @@ extension View {
         }
     }
 }
-

--- a/Chalkak/Common/DesignSystem/Alert/CommonAlert.swift
+++ b/Chalkak/Common/DesignSystem/Alert/CommonAlert.swift
@@ -1,0 +1,85 @@
+//
+//  CommonAlert.swift
+//  Chalkak
+//
+//  Created by finn on 7/29/25.
+//
+import SwiftUI
+
+/*
+사용 예시
+@State private var showAlert = false
+
+// 취소 액션 생략 dismiss 효과
+.alert(.deleteProject, isPresented: $showAlert) {
+    deleteProject()
+}
+
+// 취소 액션 처리
+.alert(.deleteProject, isPresented: $showAlert, 
+       cancelAction: { print("취소됨") },
+       confirmAction: { deleteProject() })
+*/
+
+/// 공통 Alert 타입 정의
+enum AlertType {
+    case deleteProject
+    case retakeVideo
+    case finishShooting
+    case retakeCurrentVideo
+    case endShooting
+    case exitWhileRecording
+    
+    var title: String {
+        switch self {
+        case .deleteProject: return "프로젝트를 삭제하시겠습니까?"
+        case .retakeVideo: return "다시 촬영할까요?"
+        case .finishShooting: return "촬영을 마치고 나갈까요?"
+        case .retakeCurrentVideo: return "다시 촬영할까요?"
+        case .endShooting: return "촬영 종료하기"
+        case .exitWhileRecording: return "다시 찍으시겠어요?"
+        }
+    }
+    
+    var message: String {
+        switch self {
+        case .deleteProject: return "프로젝트와 클립이 모두 삭제됩니다."
+        case .retakeVideo: return "방금 찍은 영상은 저장되지 않아요."
+        case .finishShooting: return "지금까지 찍은 장면은 저장돼요."
+        case .retakeCurrentVideo: return "방금 찍은 영상은 저장되지 않아요."
+        case .endShooting: return "지금까지 촬영된 클립을 저장하고 카메라로 돌아가시겠어요?"
+        case .exitWhileRecording: return "지금 나가면 방금 찍은 영상이 지워져요."
+        }
+    }
+    
+    var confirmText: String {
+        switch self {
+        case .deleteProject: return "삭제"
+        case .retakeVideo: return "나가기"
+        case .finishShooting: return "확인"
+        case .retakeCurrentVideo: return "확인"
+        case .endShooting: return "종료"
+        case .exitWhileRecording: return "확인"
+        }
+    }
+}
+
+
+extension View {
+    func alert(
+        _ type: AlertType,
+        isPresented: Binding<Bool>,
+        cancelAction: @escaping () -> Void = {},
+        confirmAction: @escaping () -> Void
+    ) -> some View {
+        self.alert(isPresented: isPresented) {
+            Alert(
+                title: Text(type.title),
+                message: Text(type.message),
+                primaryButton: .default(Text(type.confirmText), action: confirmAction),
+                secondaryButton: .cancel(Text("취소"), action: cancelAction)
+            )
+        }
+    }
+}
+

--- a/Chalkak/Common/DesignSystem/Alert/SnappieAlert.swift
+++ b/Chalkak/Common/DesignSystem/Alert/SnappieAlert.swift
@@ -1,0 +1,81 @@
+//
+//  SnappieAlert.swift
+//  Chalkak
+//
+//  Created by 정종문 on 7/29/25.
+//
+
+import SwiftUI
+
+/// 1초 후 사라지는 토스트 Alert
+struct SnappieAlert: View {
+    let message: String
+
+    init(message: String) {
+        self.message = message
+    }
+
+    var body: some View {
+        VStack(spacing: 10) {
+            Text(message)
+                .font(SnappieFont.style(.proLabel1))
+                .foregroundColor(SnappieColor.labelPrimaryNormal)
+
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 80))
+                .foregroundColor(SnappieColor.labelPrimaryNormal)
+                .frame(width: 120, height: 120)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 32)
+        .background(SnappieColor.darkNormal)
+        .cornerRadius(10)
+        .padding(.horizontal, 85)
+    }
+}
+
+struct SnappieAlertModifier: ViewModifier {
+    @Binding var isPresented: Bool
+    let message: String
+
+    func body(content: Content) -> some View {
+        ZStack {
+            content
+
+            if isPresented {
+                SnappieAlert(message: message)
+                    .transition(.opacity.combined(with: .scale(scale: 0.8)))
+                    .onAppear {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                            withAnimation(.easeOut(duration: 0.3)) {
+                                isPresented = false
+                            }
+                        }
+                    }
+            }
+        }
+        .animation(.easeInOut(duration: 0.3), value: isPresented)
+    }
+}
+
+extension View {
+    func snappieAlert(isPresented: Binding<Bool>, message: String) -> some View {
+        modifier(SnappieAlertModifier(isPresented: isPresented, message: message))
+    }
+}
+
+#Preview {
+    struct TestView: View {
+        @State private var showAlert = false
+
+        var body: some View {
+            VStack(spacing: 20) {
+                Button("내보내기") {
+                    showAlert = true
+                }
+                .snappieAlert(isPresented: $showAlert, message: "내보내기 완료")
+            }
+        }
+    }
+    return TestView()
+}

--- a/Chalkak/Common/DesignSystem/Alert/SnappieProgress.swift
+++ b/Chalkak/Common/DesignSystem/Alert/SnappieProgress.swift
@@ -1,0 +1,101 @@
+//
+//  SnappieProgress.swift
+//  Chalkak
+//
+//  Created by 정종문 on 7/29/25.
+//
+
+import SwiftUI
+
+/// 프로그레스 표시 Alert (내보내는 중 등에 사용)
+struct SnappieProgress: View {
+    let message: String
+    @State private var rotationAngle: Double = 0
+    
+    private var progressGradient: AngularGradient {
+        AngularGradient(
+            gradient: Gradient(stops: [
+                .init(color: Color("matcha-50").opacity(0), location: 0.07),
+                .init(color: Color("matcha-50").opacity(1.0), location: 0.84),
+            ]),
+            center: .center,
+            startAngle: .degrees(0),
+            endAngle: .degrees(360)
+        )
+    }
+    
+    init(message: String) {
+        self.message = message
+    }
+    
+    var body: some View {
+        VStack(spacing: 10) {
+            Text(message)
+                .font(SnappieFont.style(.proLabel1))
+                .foregroundColor(SnappieColor.labelPrimaryNormal)
+            
+            ZStack {
+                Circle()
+                    .stroke(SnappieColor.darkLight, lineWidth: 6)
+                    .frame(width: 106, height: 106)
+                
+                // Angular gradient progress
+                Circle()
+                    .trim(from: 0, to: 0.84)
+                    .stroke(progressGradient, style: StrokeStyle(lineWidth: 6, lineCap: .butt))
+                    .frame(width: 106, height: 106)
+                    .rotationEffect(.degrees(rotationAngle))
+                    .onAppear {
+                        withAnimation(.linear(duration: 1).repeatForever(autoreverses: false)) {
+                            rotationAngle = 360
+                        }
+                    }
+            }
+            .frame(width: 120, height: 120)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 32)
+        .background(SnappieColor.darkNormal)
+        .cornerRadius(10)
+        .padding(.horizontal, 85)
+    }
+}
+
+struct SnappieProgressModifier: ViewModifier {
+    @Binding var isPresented: Bool
+    let message: String
+    
+    func body(content: Content) -> some View {
+        ZStack {
+            content
+            
+            if isPresented {
+                SnappieProgress(message: message)
+                    .transition(.opacity.combined(with: .scale(scale: 0.8)))
+            }
+        }
+        .animation(.easeInOut(duration: 0.3), value: isPresented)
+    }
+}
+
+extension View {
+    func snappieProgress(isPresented: Binding<Bool>, message: String) -> some View {
+        modifier(SnappieProgressModifier(isPresented: isPresented, message: message))
+    }
+}
+
+#Preview {
+    struct TestView: View {
+        @State private var showProgress = false
+    
+        var body: some View {
+            VStack(spacing: 20) {
+                Button("저장 중") {
+                    showProgress = true
+                }
+                .snappieProgress(isPresented: $showProgress, message: "저장 중...")
+            }
+        }
+    }
+    return TestView()
+}

--- a/Chalkak/Common/DesignSystem/Alert/SnappieProgressAlert.swift
+++ b/Chalkak/Common/DesignSystem/Alert/SnappieProgressAlert.swift
@@ -1,0 +1,112 @@
+//
+//  SnappieProgressAlert.swift
+//  Chalkak
+//
+//  Created by 정종문 on 7/29/25.
+//
+
+import SwiftUI
+
+/// Progress Alert 조합 View
+/// Progress 표시 후 완료 시 Alert로 전환
+struct SnappieProgressAlert: View {
+    @Binding var isPresented: Bool
+    @Binding var isLoading: Bool
+    let loadingMessage: String
+    let completionMessage: String
+
+    var body: some View {
+        ZStack {
+            if isPresented && isLoading {
+                SnappieProgress(message: loadingMessage)
+                    .transition(.opacity.combined(with: .scale(scale: 0.8)))
+            } else if isPresented && !isLoading {
+                SnappieAlert(message: completionMessage)
+                    .transition(.opacity.combined(with: .scale(scale: 0.8)))
+                    .onAppear {
+                        // Alert는 1초 후 자동으로 사라짐
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                            withAnimation(.easeOut(duration: 0.3)) {
+                                isPresented = false
+                            }
+                        }
+                    }
+            }
+        }
+        .animation(.easeInOut(duration: 0.3), value: isLoading)
+        .animation(.easeInOut(duration: 0.3), value: isPresented)
+    }
+}
+
+struct SnappieProgressAlertModifier: ViewModifier {
+    @Binding var isPresented: Bool
+    @Binding var isLoading: Bool
+    let loadingMessage: String
+    let completionMessage: String
+
+    func body(content: Content) -> some View {
+        ZStack {
+            content
+
+            if isPresented {
+                SnappieProgressAlert(
+                    isPresented: $isPresented,
+                    isLoading: $isLoading,
+                    loadingMessage: loadingMessage,
+                    completionMessage: completionMessage
+                )
+            }
+        }
+    }
+}
+
+extension View {
+    /// Progress와 Alert를 조합한 modifier
+    /// - Parameters:
+    ///   - isPresented: 전체 UI 표시 여부
+    ///   - isLoading: 로딩 중 여부 (true: Progress, false: Alert)
+    ///   - loadingMessage: 로딩 중 메시지
+    ///   - completionMessage: 완료 메시지
+    func snappieProgressAlert(
+        isPresented: Binding<Bool>,
+        isLoading: Binding<Bool>,
+        loadingMessage: String,
+        completionMessage: String
+    ) -> some View {
+        modifier(
+            SnappieProgressAlertModifier(
+                isPresented: isPresented,
+                isLoading: isLoading,
+                loadingMessage: loadingMessage,
+                completionMessage: completionMessage
+            )
+        )
+    }
+}
+
+#Preview {
+    struct TestView: View {
+        @State private var showProgressAlert = false
+        @State private var isLoading = false
+
+        var body: some View {
+            VStack(spacing: 20) {
+                Button("저장하기") {
+                    showProgressAlert = true
+                    isLoading = true
+                }
+                .snappieProgressAlert(
+                    isPresented: $showProgressAlert,
+                    isLoading: $isLoading,
+                    loadingMessage: "저장 중...",
+                    completionMessage: "저장 완료!"
+                )
+
+                Button("HI") {
+                    isLoading = false
+                }
+            }
+        }
+    }
+    return TestView()
+}


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #142 

## ✨ PR Content
- 기본 내장 alert를 구현했습니다.
- Snappie 커스텀 Alert를 구현했습니다.

## 📸 Screenshot

<img width="121" height="114" alt="image" src="https://github.com/user-attachments/assets/f1a746c2-aa96-49f9-9c68-03db4ca73a17" />
<img width="119" height="117" alt="image" src="https://github.com/user-attachments/assets/1909448b-d9d0-4f49-868e-295c75deca6b" />


## 📍 PR Point 
- 로딩 후 Check가 뜨는 Alert는 `SnappieProgressAlert`에서 Preview예시를 참고하시면됩니다! 
- 로딩이 필요없다면 바로 `SnappieAlert` 컴포넌트를 활용하시면 됩니다.

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
