### PR TITLE
♻️ [refactor] projectID로 ProjectEdit 진입

### DIFF
--- a/Chalkak/App/ChalkakApp.swift
+++ b/Chalkak/App/ChalkakApp.swift
@@ -49,8 +49,8 @@ struct ChalkakApp: App {
                         case .projectPreview(finalVideoURL: let finalVideoURL):
                             ProjectPreviewView(finalVideoURL: finalVideoURL)
                         
-                        case .projectEdit:
-                            ProjectEditView()
+                        case .projectEdit(let projectID):
+                            ProjectEditView(projectID: projectID)
                             
                         case .projectList:
                             ProjectListView()

--- a/Chalkak/Common/Util/Enum/Path.swift
+++ b/Chalkak/Common/Util/Enum/Path.swift
@@ -12,6 +12,6 @@ enum Path: Hashable {
     case overlay(clip: Clip)
     case boundingBox(guide: Guide?)
     case projectPreview(finalVideoURL: URL)
-    case projectEdit
+    case projectEdit(projectID: String)
     case projectList
 }

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
@@ -9,8 +9,12 @@ import SwiftUI
 import AVKit
 
 struct ProjectEditView: View {
-    @StateObject private var viewModel = ProjectEditViewModel()
+    @StateObject private var viewModel: ProjectEditViewModel
     @EnvironmentObject private var coordinator: Coordinator
+    
+    init(projectID: String) {
+        self._viewModel = StateObject(wrappedValue: ProjectEditViewModel(projectID: projectID))
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -71,7 +75,6 @@ struct ProjectEditView: View {
             )
         }
         .padding(.horizontal, 16)
-        .onAppear { viewModel.loadProject() }
         .navigationTitle("프로젝트 트리밍")
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
@@ -27,10 +27,14 @@ final class ProjectEditViewModel: ObservableObject {
     var totalDuration: Double {
         editableClips.reduce(0) { $0 + $1.trimmedDuration }
     }
+    
+    // init
+    init(projectID: String) {
+        loadProject(of: projectID)
+    }
 
-    func loadProject() {
+    func loadProject(of projectID: String) {
         guard
-            let projectID = UserDefaults.standard.string(forKey: "currentProjectID"),
             let project = SwiftDataManager.shared.fetchProject(byID: projectID)
         else {
             print("프로젝트를 찾을 수 없습니다.")

--- a/Chalkak/Presentation/ProjectList/SubViews/NonEmptyProjectView.swift
+++ b/Chalkak/Presentation/ProjectList/SubViews/NonEmptyProjectView.swift
@@ -29,7 +29,7 @@ struct NonEmptyProjectView: View {
                         isChecked: project.isChecked,
                         timeCreated: project.createdAt,
                         moveToProjectEdit: {
-                            coordinator.push(.projectEdit)
+                            coordinator.push(.projectEdit(projectID: project.id))
                         },
                         deleteProject: {
                             viewModel.deleteProject(project)


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #148

## ✨ PR Content
> 작업 내용 설명을 적어주세요.

리스트 뷰에서 선택한 프로젝트를 바로 편집할 수 있도록 하기 위해서,
기존에는 UserDefaults의 currentProjectID를 사용해 ProjectEdit 화면을 띄웠지만, 이제는 외부에서 projectID를 받아서 뷰를 생성할 수 있도록 수정했습니다.

- ProjectEditView, ProjectEditVideModel의 init 수정
- Path, 호출하는 뷰

## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요

- 특이 사항 1
- 특이 사항 2

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
