### PR TITLE
✨ [Feat] #146 신규 프로젝트 알림을 현재 프로젝트 촬영중엔 표시하지 않게끔 조정

### DIFF
--- a/Chalkak/Presentation/Camera/SubViews/CameraRecordView.swift
+++ b/Chalkak/Presentation/Camera/SubViews/CameraRecordView.swift
@@ -16,12 +16,20 @@ struct CameraRecordView: View {
         project.isChecked == false
     }) private var uncheckedProjects: [Project]
 
+    // unchecked시 현재 촬영 중인 프로젝트를 제외
+    private var uncheckedProjectsExcludingCurrent: [Project] {
+        guard let currentProjectID = UserDefaults.standard.string(forKey: "currentProjectID") else {
+            return uncheckedProjects
+        }
+        return uncheckedProjects.filter { $0.id != currentProjectID }
+    }
+
     var body: some View {
         HStack(spacing: 0) {
             Button(action: {
                 coordinator.push(.projectList)
             }) {
-                Image(uncheckedProjects.isEmpty ? "projectList" : "projectListBadge")
+                Image(uncheckedProjectsExcludingCurrent.isEmpty ? "projectList" : "projectListBadge")
                     .frame(width: 48, height: 48)
             }
 

--- a/Chalkak/Presentation/Guide/Distance/SubViews/GuideCameraView.swift
+++ b/Chalkak/Presentation/Guide/Distance/SubViews/GuideCameraView.swift
@@ -12,10 +12,10 @@ struct GuideCameraView: View {
 
     @StateObject private var viewModel = BoundingBoxViewModel()
     @StateObject private var cameraViewModel = CameraViewModel()
-    
+
     init(guide: Guide?) {
         self.guide = guide
-        
+
         let cameraVM = CameraViewModel()
         self._cameraViewModel = StateObject(wrappedValue: cameraVM)
         self._viewModel = StateObject(
@@ -25,7 +25,7 @@ struct GuideCameraView: View {
             )
         )
     }
-    
+
     var body: some View {
         ZStack {
             CameraView(guide: guide, isAligned: viewModel.isAligned, viewModel: cameraViewModel)
@@ -45,9 +45,10 @@ struct GuideCameraView: View {
                     .padding(.horizontal, 16)
                     .frame(maxHeight: .infinity, alignment: .top)
             } else {
-                Text("윤곽선 이미지 없음")
-                    .foregroundColor(.gray)
+                Text("가이드를 생성하지못했어요.\n인물이 나오는 장면을 촬영해주세요")
+                    .foregroundColor(SnappieColor.labelPrimaryNormal)
                     .allowsHitTesting(false)
+                    .multilineTextAlignment(.center)
             }
 
             // Tilt 피드백 뷰

--- a/Chalkak/Presentation/Guide/Overlay/SubViews/OverlayDisplayView.swift
+++ b/Chalkak/Presentation/Guide/Overlay/SubViews/OverlayDisplayView.swift
@@ -41,8 +41,9 @@ struct OverlayDisplayView: View {
                     .resizable()
                     .aspectRatio(contentMode: .fit)
             } else {
-                Text("윤곽선 이미지 없음")
+                Text("가이드를 생성하지못했어요.\n인물이 나오는 장면을 촬영해주세요")
                     .foregroundColor(.gray)
+                    .multilineTextAlignment(.center)
             }
         }
     }


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #146, #159

## ✨ PR Content
- 현재 프로젝트가 생성되었을때 촬영 중에 흐름이 끊기지않게 currentProjectId오ㅓ 비교하여 알림 비활성화처리 로직을 추가하였습니다.
- #159 의 이슈인 오버레이 가이드 생성 실패시 UI를 조정했습니다.


## 📸 Screenshot

#159 
<img width="645" height="1398" alt="IMG_3680" src="https://github.com/user-attachments/assets/13e7356d-7f3b-4ad5-81b5-d140f210fc04" />


## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요
- 특이 사항 1

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
