### PR TITLE
✨ [feat] #161 기능 분기별 Alert 처리 로직 구현

### DIFF
--- a/Chalkak/Common/DesignSystem/Alert/CommonAlert.swift
+++ b/Chalkak/Common/DesignSystem/Alert/CommonAlert.swift
@@ -42,7 +42,7 @@ enum AlertType {
         switch self {
         case .deleteProject: return "삭제"
         case .retakeVideo: return "나가기"
-        case .finishShooting: return "확인"
+        case .finishShooting: return "나가기"
         case .retakeCurrentVideo: return "확인"
         case .endShooting: return "종료"
         case .exitWhileRecording: return "확인"
@@ -76,8 +76,8 @@ extension View {
             Alert(
                 title: Text(type.title),
                 message: Text(type.message),
-                primaryButton: .default(Text(type.confirmText), action: confirmAction),
-                secondaryButton: .cancel(Text("취소"), action: cancelAction)
+                primaryButton: .cancel(Text("취소"), action: cancelAction),
+                secondaryButton: .default(Text(type.confirmText), action: confirmAction)
             )
         }
     }

--- a/Chalkak/Common/DesignSystem/Alert/SnappieAlert.swift
+++ b/Chalkak/Common/DesignSystem/Alert/SnappieAlert.swift
@@ -10,9 +10,11 @@ import SwiftUI
 /// 1초 후 사라지는 토스트 Alert
 struct SnappieAlert: View {
     let message: String
+    let showImage: Bool
 
-    init(message: String) {
+    init(message: String, showImage: Bool = true) {
         self.message = message
+        self.showImage = showImage
     }
 
     var body: some View {
@@ -21,10 +23,12 @@ struct SnappieAlert: View {
                 .font(SnappieFont.style(.proLabel1))
                 .foregroundColor(SnappieColor.labelPrimaryNormal)
 
-            Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 80))
-                .foregroundColor(SnappieColor.labelPrimaryNormal)
-                .frame(width: 120, height: 120)
+            if showImage {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 80))
+                    .foregroundColor(SnappieColor.labelPrimaryNormal)
+                    .frame(width: 120, height: 120)
+            }
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 32)
@@ -37,13 +41,14 @@ struct SnappieAlert: View {
 struct SnappieAlertModifier: ViewModifier {
     @Binding var isPresented: Bool
     let message: String
+    let showImage: Bool
 
     func body(content: Content) -> some View {
         ZStack {
             content
 
             if isPresented {
-                SnappieAlert(message: message)
+                SnappieAlert(message: message, showImage: showImage)
                     .transition(.opacity.combined(with: .scale(scale: 0.8)))
                     .onAppear {
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
@@ -60,7 +65,11 @@ struct SnappieAlertModifier: ViewModifier {
 
 extension View {
     func snappieAlert(isPresented: Binding<Bool>, message: String) -> some View {
-        modifier(SnappieAlertModifier(isPresented: isPresented, message: message))
+        modifier(SnappieAlertModifier(isPresented: isPresented, message: message, showImage: true))
+    }
+    
+    func snappieAlert(isPresented: Binding<Bool>, message: String, showImage: Bool) -> some View {
+        modifier(SnappieAlertModifier(isPresented: isPresented, message: message, showImage: showImage))
     }
 }
 

--- a/Chalkak/Data/SwiftDataManager.swift
+++ b/Chalkak/Data/SwiftDataManager.swift
@@ -121,7 +121,7 @@ class SwiftDataManager {
     /// 프로젝트에 'coverImage' 업데이트
     func updateProjectCoverImage(projectID: String, coverImage: UIImage) {
         guard let project = fetchProject(byID: projectID) else {
-            print("⚠️ 해당 Project(\(projectID))를 찾을 수 없습니다.")
+            print("해당 Project(\(projectID))를 찾을 수 없습니다.")
             return
         }
 
@@ -145,14 +145,19 @@ class SwiftDataManager {
     /// 프로젝트 확인 상태 업데이트
     func markProjectAsChecked(projectID: String) {
         guard let project = fetchProject(byID: projectID) else {
-            print("⚠️ 해당 Project(\(projectID))를 찾을 수 없습니다.")
+            print("해당 Project(\(projectID))를 찾을 수 없습니다.")
             return
         }
+        
         project.isChecked = true
         saveContext()
+        
+        // 뱃지 상태 최신화
+        DispatchQueue.main.async {
+            try? self.context.save()
+        }
     }
     
-
     // MARK: - Clip
 
     /// `Clip` 생성: Clip 객체 데이터로

--- a/Chalkak/Data/SwiftDataManager.swift
+++ b/Chalkak/Data/SwiftDataManager.swift
@@ -142,6 +142,21 @@ class SwiftDataManager {
         return (try? context.fetch(descriptor)) ?? []
     }
     
+    /// 뱃지 표시용 확인하지 않은 프로젝트 조회 (guide가 있고, 현재 촬영 중이 아닌 것)
+    func getUncheckedProjectsForBadge() -> [Project] {
+        let predicate = #Predicate<Project> { project in
+            project.isChecked == false && project.guide != nil
+        }
+        let descriptor = FetchDescriptor<Project>(predicate: predicate)
+        let uncheckedProjects = (try? context.fetch(descriptor)) ?? []
+        
+        // 현재 촬영 중인 프로젝트 제외
+        guard let currentProjectID = UserDefaults.standard.string(forKey: "currentProjectID") else {
+            return uncheckedProjects
+        }
+        return uncheckedProjects.filter { $0.id != currentProjectID }
+    }
+    
     /// 프로젝트 확인 상태 업데이트
     func markProjectAsChecked(projectID: String) {
         guard let project = fetchProject(byID: projectID) else {

--- a/Chalkak/Presentation/Camera/CameraView.swift
+++ b/Chalkak/Presentation/Camera/CameraView.swift
@@ -18,6 +18,7 @@ struct CameraView: View {
     @State private var navigateToEdit = false
     @State private var feedbackOpacity: Double = 0
     @State private var fadeOutTask: Task<Void, Never>?
+    @State private var showExitAlert = false
 
     var body: some View {
         ZStack {
@@ -46,7 +47,7 @@ struct CameraView: View {
                         .foregroundColor(SnappieColor.labelPrimaryNormal)
                         .opacity(feedbackOpacity)
                 }
-                
+
                 // 타이머 카운트다운 오버레이
                 if viewModel.isTimerRunning && viewModel.timerCountdown > 0 {
                     Text("\(viewModel.timerCountdown)")
@@ -65,8 +66,29 @@ struct CameraView: View {
                 HorizontalLevelIndicatorView(gravityX: viewModel.tiltCollector.gravityX)
             }
 
+            // 두번째 촬영부터-중간이탈버튼
+            if guide != nil {
+                VStack {
+                    HStack {
+                        SnappieButton(.iconBackground(
+                            icon: .dismiss,
+                            size: .large,
+                            isActive: true
+                        )) {
+                            showExitAlert = true
+                        }
+                        .padding(.leading, 30)
+                        .padding(.top, 25)
+
+                        Spacer()
+                    }
+
+                    Spacer()
+                }
+            }
+
             VStack {
-                CameraTopControlView(viewModel: viewModel)
+                CameraTopControlView(viewModel: viewModel, guide: guide)
 
                 Spacer()
 
@@ -115,6 +137,14 @@ struct CameraView: View {
         .onDisappear {
             viewModel.stopCamera()
         }
+        .alert(.finishShooting, isPresented: $showExitAlert) {
+            handleExitCamera()
+        }
+    }
+
+    private func handleExitCamera() {
+        viewModel.stopCamera()
+        coordinator.removeAll()
     }
 }
 

--- a/Chalkak/Presentation/Camera/CameraView.swift
+++ b/Chalkak/Presentation/Camera/CameraView.swift
@@ -140,6 +140,7 @@ struct CameraView: View {
         .alert(.finishShooting, isPresented: $showExitAlert) {
             handleExitCamera()
         }
+        .snappieAlert(isPresented: $viewModel.showProjectSavedAlert, message: "프로젝트가 저장되었습니다")
     }
 
     private func handleExitCamera() {

--- a/Chalkak/Presentation/Camera/CameraViewModel.swift
+++ b/Chalkak/Presentation/Camera/CameraViewModel.swift
@@ -22,7 +22,6 @@ class CameraViewModel: ObservableObject {
 
     // 비디오 저장 완료 이벤트를 View로 전달
     let videoSavedPublisher = PassthroughSubject<URL, Never>()
-    
 
     @Published var isTimerRunning = false
     @Published var selectedTimerDuration: TimerOptions = .off
@@ -58,6 +57,7 @@ class CameraViewModel: ObservableObject {
     @Published var showingZoomControl = false
     @Published var zoomScale: CGFloat = 1.0
     @Published var isUsingFrontCamera: Bool = false
+    @Published var hasBadge: Bool = false
 
     // 줌 범위  수정 가능
     var minZoomScale: CGFloat { 0.5 }
@@ -94,6 +94,11 @@ class CameraViewModel: ObservableObject {
         loadSavedSettings()
 
         configure()
+
+        // 뱃지 상태 초기화
+        Task { @MainActor in
+            updateBadgeState()
+        }
 
         // 저장되어있는 줌스케일 적용
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
@@ -374,5 +379,12 @@ class CameraViewModel: ObservableObject {
         zoomScale = savedZoomScale
         selectedTimerDuration = TimerOptions(rawValue: savedTimer) ?? .off
         cameraPostion = savedIsFront ? .front : .back
+    }
+
+    /// 뱃지 상태 업데이트
+    @MainActor
+    func updateBadgeState() {
+        let uncheckedProjects = SwiftDataManager.shared.getUncheckedProjectsForBadge()
+        hasBadge = !uncheckedProjects.isEmpty
     }
 }

--- a/Chalkak/Presentation/Camera/CameraViewModel.swift
+++ b/Chalkak/Presentation/Camera/CameraViewModel.swift
@@ -58,6 +58,7 @@ class CameraViewModel: ObservableObject {
     @Published var zoomScale: CGFloat = 1.0
     @Published var isUsingFrontCamera: Bool = false
     @Published var hasBadge: Bool = false
+    @Published var showProjectSavedAlert: Bool = false
 
     // 줌 범위  수정 가능
     var minZoomScale: CGFloat { 0.5 }
@@ -386,5 +387,11 @@ class CameraViewModel: ObservableObject {
     func updateBadgeState() {
         let uncheckedProjects = SwiftDataManager.shared.getUncheckedProjectsForBadge()
         hasBadge = !uncheckedProjects.isEmpty
+    }
+    
+    /// 프로젝트 저장 알림 표시
+    @MainActor
+    func showProjectSavedNotification() {
+        showProjectSavedAlert = true
     }
 }

--- a/Chalkak/Presentation/Camera/SubViews/CameraRecordView.swift
+++ b/Chalkak/Presentation/Camera/SubViews/CameraRecordView.swift
@@ -11,20 +11,13 @@ import SwiftUI
 struct CameraRecordView: View {
     @ObservedObject var viewModel: CameraViewModel
     @EnvironmentObject private var coordinator: Coordinator
-    @State private var hasBadge = false
-
-    // SwiftDataManager를 통한 뱃지 상태 확인
-    private func updateBadgeState() {
-        let uncheckedProjects = SwiftDataManager.shared.getUncheckedProjectsForBadge()
-        hasBadge = !uncheckedProjects.isEmpty
-    }
 
     var body: some View {
         HStack(spacing: 0) {
             Button(action: {
                 coordinator.push(.projectList)
             }) {
-                Image(hasBadge ? "projectListBadge" : "projectList")
+                Image(viewModel.hasBadge ? "projectListBadge" : "projectList")
                     .frame(width: 48, height: 48)
             }
 
@@ -51,11 +44,15 @@ struct CameraRecordView: View {
         .padding(.bottom, Layout.recordButtonBottomPadding)
         .padding(.horizontal, Layout.recordButtonHorizontalPadding)
         .onAppear {
-            updateBadgeState()
+            Task { @MainActor in
+                viewModel.updateBadgeState()
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: .NSManagedObjectContextDidSave)) { _ in
             // SwiftData 변경사항이 있을 때 뱃지 상태 업데이트
-            updateBadgeState()
+            Task { @MainActor in
+                viewModel.updateBadgeState()
+            }
         }
     }
 }

--- a/Chalkak/Presentation/Camera/SubViews/CameraRecordView.swift
+++ b/Chalkak/Presentation/Camera/SubViews/CameraRecordView.swift
@@ -13,7 +13,7 @@ struct CameraRecordView: View {
     @EnvironmentObject private var coordinator: Coordinator
 
     @Query(filter: #Predicate<Project> { project in
-        project.isChecked == false
+        project.isChecked == false && project.guide != nil
     }) private var uncheckedProjects: [Project]
 
     // unchecked시 현재 촬영 중인 프로젝트를 제외

--- a/Chalkak/Presentation/Camera/SubViews/CameraRecordView.swift
+++ b/Chalkak/Presentation/Camera/SubViews/CameraRecordView.swift
@@ -46,6 +46,12 @@ struct CameraRecordView: View {
         .onAppear {
             Task { @MainActor in
                 viewModel.updateBadgeState()
+                
+                // 프로젝트 완료 후 홈으로 돌아왔을 때 알림 표시
+                if UserDefaults.standard.bool(forKey: "showProjectSavedAlert") {
+                    UserDefaults.standard.set(false, forKey: "showProjectSavedAlert")
+                    viewModel.showProjectSavedNotification()
+                }
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .NSManagedObjectContextDidSave)) { _ in

--- a/Chalkak/Presentation/Camera/SubViews/CameraTopControlView.swift
+++ b/Chalkak/Presentation/Camera/SubViews/CameraTopControlView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct CameraTopControlView: View {
     @ObservedObject var viewModel: CameraViewModel
+    let guide: Guide?
 
     var body: some View {
         HStack {

--- a/Chalkak/Presentation/ClipEdit/ClipEditView.swift
+++ b/Chalkak/Presentation/ClipEdit/ClipEditView.swift
@@ -24,11 +24,11 @@ import SwiftUI
  ├─ guide != nil
       1) "내보내기" 버튼이 표시됨
       2) "다음" 버튼 → 기존 Project에 새로운 Clip 모델 추가
- 
+
  ## 구성 요소(서브뷰)
  - VideoPreviewView: 영상의 현재 구간을 보여주는 프리뷰 뷰
  - TrimmingControlView: 영상 재생 버튼과 트리밍 타임라인 UI를 포함한 조작 패널
- 
+
  ## 호출 위치
  - CameraView → ClipEditView로 이동
  - 호출 예시:
@@ -51,7 +51,8 @@ struct ClipEditView: View {
     @State private var isDragging = false
     @State private var autoPlayEnabled = true
     @State private var showActionSheet = false
-    
+    @State private var showRetakeAlert = false
+
     // 3. init
     init(
         clipURL: URL,
@@ -63,23 +64,23 @@ struct ClipEditView: View {
             clipURL: clipURL,
             cameraSetting: cameraSetting,
             timeStampedTiltList: timeStampedTiltList
-            )
+        )
         )
         self.guide = guide
         self.cameraSetting = cameraSetting
     }
-    
+
     // 4. body
     var body: some View {
         ZStack {
             SnappieColor.darkHeavy
                 .ignoresSafeArea()
-            
+
             VStack(alignment: .center, spacing: 16, content: {
                 SnappieNavigationBar(
                     navigationTitle: "클립 편집",
                     leftButtonType: .backward {
-                        coordinator.popLast()
+                        showRetakeAlert = true
                     },
                     rightButtonType: guide != nil ?
                         .oneButton(
@@ -118,7 +119,7 @@ struct ClipEditView: View {
             Button("촬영 이어가기") {
                 // 트리밍한 클립 프로젝트에 추가
                 editViewModel.appendClipToCurrentProject()
-                
+
                 // 가이드 카메라로 이동
                 if let guide = guide {
                     coordinator.push(.boundingBox(guide: guide))
@@ -131,9 +132,12 @@ struct ClipEditView: View {
                 coordinator.push(.projectPreview)
             }
 
-            Button("Cancel", role: .cancel) { }
+            Button("Cancel", role: .cancel) {}
         } message: {
             Text("이어서 찍거나 전체 영상 편집으로 이동할 수 있습니다.")
+        }
+        .alert(.retakeVideo, isPresented: $showRetakeAlert) {
+            coordinator.popLast()
         }
         .task {
             if guide != nil {

--- a/Chalkak/Presentation/ProjectList/ProjectListView.swift
+++ b/Chalkak/Presentation/ProjectList/ProjectListView.swift
@@ -47,6 +47,7 @@ struct ProjectListView: View {
             }
         }
         .navigationBarBackButtonHidden()
+        .snappieAlert(isPresented: $viewModel.showProjectDeletedAlert, message: "프로젝트 삭제됨", showImage: false)
     }
 }
 

--- a/Chalkak/Presentation/ProjectList/ProjectListViewModel.swift
+++ b/Chalkak/Presentation/ProjectList/ProjectListViewModel.swift
@@ -13,6 +13,7 @@ import SwiftData
 @MainActor
 final class ProjectListViewModel: ObservableObject {
     @Published var projects: [Project] = []
+    @Published var showProjectDeletedAlert: Bool = false
 
     init() {
         fetchProjects()
@@ -37,6 +38,7 @@ final class ProjectListViewModel: ObservableObject {
     func deleteProject(_ project: Project) {
         SwiftDataManager.shared.deleteProject(project)
         fetchProjects()
+        showProjectDeletedAlert = true
     }
     
     /// 프로젝트 이름 변경

--- a/Chalkak/Presentation/ProjectPreview/ProjectPreviewView.swift
+++ b/Chalkak/Presentation/ProjectPreview/ProjectPreviewView.swift
@@ -11,11 +11,13 @@ import SwiftUI
 /// 합본 영상을 확인하고 갤러리로 내보내기 할 수 있는 뷰
 struct ProjectPreviewView: View {
     // MARK: Property Wrappers
+
     @StateObject private var viewModel = ProjectPreviewViewModel()
     @EnvironmentObject private var coordinator: Coordinator
     @State private var showSuccessAlert = false
-    
+
     // MARK: body
+
     var body: some View {
         ZStack {
             SnappieColor.darkHeavy.ignoresSafeArea()
@@ -24,6 +26,10 @@ struct ProjectPreviewView: View {
                 SnappieNavigationBar(
                     leftButtonType: .dismiss {
                         viewModel.clearCurrentProjectID()
+
+                        // 홈으로 이동 후 alert를 위한 userdefaults플래그 설정
+                        UserDefaults.standard.set(true, forKey: "showProjectSavedAlert")
+
                         coordinator.removeAll()
                     },
                     rightButtonType: .oneButton(.init(


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #161 

## ✨ PR Content
- 분기별 Alert를 추가하였습니다.
- 두번째 촬영시점부터 좌측상단에 dismiss 역할의 X아이콘이 추가되었습니다.
- 신규 프로젝트에 따른 프로젝트 리스트 버튼의 UI 적용 로직을 View로 부터 분리하였습니다. 

## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요
- 특이 사항 1
Alert의 버튼별 색, bold처리와 같은거는 상세하게 조절이 안되는게 원래 맞을까요? role로 구성되어있는 포맷말고는 별도로 조절이 잘 안되는 것 같네요..! `UIAlertController`를 활용해야하는 것 같은데, 이 부분은 추후에 활용을 해보겠습니다..! 

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
