### PR TITLE
[Feat] #155 프로젝트 영상 시간(duration) 적용

### DIFF
--- a/Chalkak/Core/Guide/Overlay/OverlayManager.swift
+++ b/Chalkak/Core/Guide/Overlay/OverlayManager.swift
@@ -6,7 +6,6 @@
 //
 
 import CoreImage
-import CoreImage.CIFilterBuiltins
 import UIKit
 import Vision
 

--- a/Chalkak/Data/Model/Clip.swift
+++ b/Chalkak/Data/Model/Clip.swift
@@ -37,7 +37,7 @@ class Clip {
     
     /// 트리밍된 시간을 계산한 정보.
     var currentTrimmedDuration: Double {
-        return endPoint - startPoint
+        max(0, endPoint - startPoint)
     }
     
     /// 새로운 Clip 인스턴스를 초기화합니다.

--- a/Chalkak/Data/Model/Project.swift
+++ b/Chalkak/Data/Model/Project.swift
@@ -42,6 +42,9 @@ class Project: Identifiable {
     /// 프로젝트 생성 시간
     var createdAt: Date
     
+    /// 전체 프로젝트 영상 길이
+    var totalDuration: Double
+    
     /// 새로운 `Project` 인스턴스를 초기화합니다.
     /// - Parameters:
     ///   - id: 고유 식별자 (기본값은 자동 생성된 UUID).
@@ -56,7 +59,8 @@ class Project: Identifiable {
         referenceDuration: Double? = nil,
         isChecked: Bool = false,
         coverImage: Data? = nil,
-        createdAt: Date = Date()
+        createdAt: Date = Date(),
+        totalDuration: Double = 0
     ) {
         self.id = id
         self.guide = guide
@@ -67,5 +71,6 @@ class Project: Identifiable {
         self.isChecked = isChecked
         self.coverImage = coverImage
         self.createdAt = createdAt
+        self.totalDuration = totalDuration
     }
 }

--- a/Chalkak/Data/Model/Project.swift
+++ b/Chalkak/Data/Model/Project.swift
@@ -43,7 +43,9 @@ class Project: Identifiable {
     var createdAt: Date
     
     /// 전체 프로젝트 영상 길이
-    var totalDuration: Double
+    var totalDuration: Double {
+        clipList.reduce(0) { $0 + $1.currentTrimmedDuration }
+    }
     
     /// 새로운 `Project` 인스턴스를 초기화합니다.
     /// - Parameters:
@@ -59,8 +61,7 @@ class Project: Identifiable {
         referenceDuration: Double? = nil,
         isChecked: Bool = false,
         coverImage: Data? = nil,
-        createdAt: Date = Date(),
-        totalDuration: Double = 0
+        createdAt: Date = Date()
     ) {
         self.id = id
         self.guide = guide
@@ -71,6 +72,5 @@ class Project: Identifiable {
         self.isChecked = isChecked
         self.coverImage = coverImage
         self.createdAt = createdAt
-        self.totalDuration = totalDuration
     }
 }

--- a/Chalkak/Data/SwiftDataManager.swift
+++ b/Chalkak/Data/SwiftDataManager.swift
@@ -78,8 +78,7 @@ class SwiftDataManager {
         referenceDuration: Double? = nil,
         isChecked: Bool = false,
         coverImage: Data? = nil,
-        createdAt: Date = Date(),
-        totalDuration: Double = 0
+        createdAt: Date = Date()
     ) -> Project {
         let project = Project(
             id: id,
@@ -90,8 +89,7 @@ class SwiftDataManager {
             referenceDuration: referenceDuration,
             isChecked: isChecked,
             coverImage: coverImage,
-            createdAt: createdAt,
-            totalDuration: totalDuration
+            createdAt: createdAt
         )
         context.insert(project)
         return project

--- a/Chalkak/Data/SwiftDataManager.swift
+++ b/Chalkak/Data/SwiftDataManager.swift
@@ -78,7 +78,8 @@ class SwiftDataManager {
         referenceDuration: Double? = nil,
         isChecked: Bool = false,
         coverImage: Data? = nil,
-        createdAt: Date = Date()
+        createdAt: Date = Date(),
+        totalDuration: Double = 0
     ) -> Project {
         let project = Project(
             id: id,
@@ -89,7 +90,8 @@ class SwiftDataManager {
             referenceDuration: referenceDuration,
             isChecked: isChecked,
             coverImage: coverImage,
-            createdAt: createdAt
+            createdAt: createdAt,
+            totalDuration: totalDuration
         )
         context.insert(project)
         return project

--- a/Chalkak/Presentation/ClipEdit/ClipEditViewModel.swift
+++ b/Chalkak/Presentation/ClipEdit/ClipEditViewModel.swift
@@ -282,8 +282,7 @@ final class ClipEditViewModel: ObservableObject {
             title: generatedTitle,
             referenceDuration: clip.endPoint - clip.startPoint,
             coverImage: nil,
-            createdAt: createdAt,
-            totalDuration: clip.currentTrimmedDuration
+            createdAt: createdAt
         )
     
         SwiftDataManager.shared.saveContext()
@@ -335,7 +334,6 @@ final class ClipEditViewModel: ObservableObject {
         }
 
         project.clipList.append(clip)
-        project.totalDuration += clip.currentTrimmedDuration
         SwiftDataManager.shared.saveContext()
     }
 }

--- a/Chalkak/Presentation/ClipEdit/ClipEditViewModel.swift
+++ b/Chalkak/Presentation/ClipEdit/ClipEditViewModel.swift
@@ -282,7 +282,8 @@ final class ClipEditViewModel: ObservableObject {
             title: generatedTitle,
             referenceDuration: clip.endPoint - clip.startPoint,
             coverImage: nil,
-            createdAt: createdAt
+            createdAt: createdAt,
+            totalDuration: clip.currentTrimmedDuration
         )
     
         SwiftDataManager.shared.saveContext()
@@ -311,8 +312,6 @@ final class ClipEditViewModel: ObservableObject {
         )
     }
     
-    /// 기존 Project에 새로운 Clip을 추가
-    /// UserDefaults에 저장된 currentProjectID를 기준으로 Project를 찾아 clipList에 추가
     @MainActor
     func saveCameraSetting() -> CameraSetting {
         return SwiftDataManager.shared.createCameraSetting(
@@ -323,6 +322,8 @@ final class ClipEditViewModel: ObservableObject {
         )
     }
     
+    /// 기존 Project에 새로운 Clip을 추가
+    /// UserDefaults에 저장된 currentProjectID를 기준으로 Project를 찾아 clipList에 추가
     @MainActor
     func appendClipToCurrentProject() {
         let clip = saveClipData()
@@ -334,6 +335,7 @@ final class ClipEditViewModel: ObservableObject {
         }
 
         project.clipList.append(clip)
+        project.totalDuration += clip.currentTrimmedDuration
         SwiftDataManager.shared.saveContext()
     }
 }

--- a/Chalkak/Presentation/ProjectList/SubViews/NonEmptyProjectView.swift
+++ b/Chalkak/Presentation/ProjectList/SubViews/NonEmptyProjectView.swift
@@ -24,7 +24,7 @@ struct NonEmptyProjectView: View {
                     ProjectCardView(
                         isCurrentProject: viewModel.isCurrentProject(project),
                         image: Image(uiImage: UIImage(data: project.coverImage ?? Data()) ?? UIImage()),
-                        time: 150, // TODO: 전체 길이 계산해서 넣기
+                        time: project.totalDuration,
                         projectTitle: project.title,
                         isChecked: project.isChecked,
                         timeCreated: project.createdAt,


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #155

## ✨ PR Content
> 작업 내용 설명을 적어주세요.
프로젝트 영상 시간(duration) 적용

클립 추가, 삭제, 편집 시, 프로젝트 전체 영상의 길이(totalDuration) 값이 바뀜
이는 프로젝트 리스트 화면에서 출력됩니다.


## 📸 Screenshot
> 작업 화면의 스크린샷을 추가해주세요.

3초짜리 영상 4개 촬영 후, 프로젝트 리스트 화면에서 영상의 길이가 12초가 되는 것을 확인했습니다.

## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요

- 특이 사항 1
- 특이 사항 2

## ✅ Checklist
- [X] Merge 하는 브랜치가 올바른지 확인
- [X] 필요없는 주석, 프린트문 제거했는지 확인
- [X] PR과 관련없는 변경사항 없는지 확인
- [X] 컨벤션 지켰는지 확인
