### PR TITLE
✨ [Feat] 프로젝트 편집 내역 저장 및 navigation 로직 구현

### DIFF
--- a/Chalkak/Core/VideoEditor/VideoManager.swift
+++ b/Chalkak/Core/VideoEditor/VideoManager.swift
@@ -80,4 +80,21 @@ class VideoManager: ObservableObject {
             throw VideoMergerError.exportFailed
         }
     }
+    
+    func processAndSaveVideo(clips: [EditableClip]) async throws -> URL {
+        // 편집된 클립을 클립 모델 데이터로 변환
+        let mergerClips = clips.map { clip in
+            Clip(
+                id: clip.id,
+                videoURL: clip.url,
+                originalDuration: clip.originalDuration,
+                startPoint: clip.startPoint,
+                endPoint: clip.endPoint
+            )
+        }
+        // VideoMerger 사용해 영상 병합
+        let videoMerger = VideoMerger()
+        let outputURL = try await videoMerger.mergeVideos(from: mergerClips)
+        return outputURL
+    }
 }

--- a/Chalkak/Presentation/ClipEdit/ClipEditView.swift
+++ b/Chalkak/Presentation/ClipEdit/ClipEditView.swift
@@ -112,11 +112,11 @@ struct ClipEditView: View {
         }
         .navigationBarBackButtonHidden(true)
         .confirmationDialog(
-            "A Short Title is Best",
+            "다음 장면을 이어서 촬영할까요?",
             isPresented: $showActionSheet,
             titleVisibility: .visible
         ) {
-            Button("촬영 이어가기") {
+            Button("이어서 촬영하기") {
                 // 트리밍한 클립 프로젝트에 추가
                 editViewModel.appendClipToCurrentProject()
 
@@ -126,15 +126,15 @@ struct ClipEditView: View {
                 }
             }
 
-            Button("촬영 프로세스 마치기") {
+            Button("촬영 마치기") {
                 // 트리밍한 클립 프로젝트에 추가
                 editViewModel.appendClipToCurrentProject()
                 coordinator.push(.projectPreview)
             }
 
-            Button("Cancel", role: .cancel) {}
+            Button("취소", role: .cancel) {}
         } message: {
-            Text("이어서 찍거나 전체 영상 편집으로 이동할 수 있습니다.")
+            Text("지금 이어서 찍거나, 프로젝트를 마무리할 수 있어요.")
         }
         .alert(.retakeVideo, isPresented: $showRetakeAlert) {
             coordinator.popLast()

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
@@ -12,6 +12,9 @@ import AVKit
 struct ProjectEditView: View {
     @StateObject private var viewModel: ProjectEditViewModel
     @EnvironmentObject private var coordinator: Coordinator
+    @State private var showExitConfirmation = false
+    @State private var showExportSuccessAlert = false
+    @State private var isExporting = false
     
     init(projectID: String) {
         self._viewModel = StateObject(wrappedValue: ProjectEditViewModel(projectID: projectID))
@@ -22,16 +25,17 @@ struct ProjectEditView: View {
             SnappieNavigationBar(
                 navigationTitle: "프로젝트 편집",
                 leftButtonType: .backward {
-                    // TODO: confirmation dialog 띄우기(ssol)
-                    // 임시로 현재 화면 빠져나가도록 처리했습니다. 추후 수정 예정
-                    coordinator.popLast()
+                    showExitConfirmation = true
                 },
                 rightButtonType: .oneButton(.init(label: "내보내기") {
-                    // TODO: 영상 사진 앱으로 내보내기 로직 연결(ssol)
+                    Task {
+                        await viewModel.exportEditedVideoToPhotos()
+                        showExportSuccessAlert = true
+                    }
                 })
             )
             .padding(.bottom, 16)
-
+            
             ZStack {
                 VideoPreviewView(
                     previewImage: viewModel.previewImage,
@@ -89,6 +93,33 @@ struct ProjectEditView: View {
         .background(
             SnappieColor.darkHeavy
                 .ignoresSafeArea()
+        )
+        // 뒤로가기 확인 다이얼로그
+        .confirmationDialog(
+            "편집된 내용을 저장할까요? 저장하지 않으면 편집 내용이 사라집니다.",
+            isPresented: $showExitConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("저장하기") {
+                viewModel.saveProjectChanges()
+                coordinator.popLast()
+            }
+            Button("저장하지 않고 나가기", role: .destructive) {
+                coordinator.popLast()
+            }
+            Button("취소", role: .cancel) {}
+        }
+        // 내보내기 완료 알림
+        .snappieAlert(
+            isPresented: $showExportSuccessAlert,
+            message: "내보내기 완료"
+        )
+        // 진행중 로딩 프로그레스
+        .snappieProgressAlert(
+            isPresented: $isExporting,
+            isLoading: $isExporting,
+            loadingMessage: "영상 내보내는 중...",
+            completionMessage: ""
         )
     }
 }

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
@@ -94,9 +94,10 @@ struct ProjectEditView: View {
             SnappieColor.darkHeavy
                 .ignoresSafeArea()
         )
+        
         // 뒤로가기 확인 다이얼로그
         .confirmationDialog(
-            "편집된 내용을 저장할까요? 저장하지 않으면 편집 내용이 사라집니다.",
+            "편집된 내용을 저장할까요?",
             isPresented: $showExitConfirmation,
             titleVisibility: .visible
         ) {
@@ -104,16 +105,20 @@ struct ProjectEditView: View {
                 viewModel.saveProjectChanges()
                 coordinator.popLast()
             }
-            Button("저장하지 않고 나가기", role: .destructive) {
+            Button("저장하지 않고 나가기") {
                 coordinator.popLast()
             }
             Button("취소", role: .cancel) {}
+        } message: {
+            Text("저장하지 않으면 편집 내용이 사라집니다.")
         }
+        
         // 내보내기 완료 알림
         .snappieAlert(
             isPresented: $showExportSuccessAlert,
             message: "내보내기 완료"
         )
+        
         // 진행중 로딩 프로그레스
         .snappieProgressAlert(
             isPresented: $isExporting,

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
@@ -97,7 +97,7 @@ struct ProjectEditView: View {
         
         // 뒤로가기 확인 다이얼로그
         .confirmationDialog(
-            "편집된 내용을 저장할까요?",
+            "편집한 내용을 저장할까요?",
             isPresented: $showExitConfirmation,
             titleVisibility: .visible
         ) {
@@ -110,7 +110,7 @@ struct ProjectEditView: View {
             }
             Button("취소", role: .cancel) {}
         } message: {
-            Text("저장하지 않으면 편집 내용이 사라집니다.")
+            Text("저장하지 않으면 방금 편집한 내용이 사라져요.")
         }
         
         // 내보내기 완료 알림

--- a/Chalkak/Presentation/ProjectEdit/SubViews/ProjectThumbnailsView.swift
+++ b/Chalkak/Presentation/ProjectEdit/SubViews/ProjectThumbnailsView.swift
@@ -11,16 +11,37 @@ struct ProjectThumbnailsView: View {
     let clip: EditableClip
     let fullWidth: CGFloat
 
+    /// 원하는 썸네일 개수 (초당 3개)
+    private var countWanted: Int {
+        let duration = clip.isTrimming ? clip.originalDuration : clip.trimmedDuration
+        let rate: Double = 3 // 초당 썸네일 개수
+        return max(1, Int(floor(duration * rate)))
+    }
+
+    /// 실제 표시할 썸네일 배열
+    private var thumbsToShow: [UIImage] {
+        let available = clip.thumbnails.count
+        let n = min(countWanted, available)
+        guard available > n else { return clip.thumbnails }
+        let step = Double(available - 1) / Double(n - 1)
+        return (0..<n).map { idx in
+            let i = Int(round(step * Double(idx)))
+            return clip.thumbnails[i]
+        }
+    }
+
+    /// 썸네일 하나당 너비
+    private var thumbnailWidth: CGFloat {
+        fullWidth / CGFloat(max(thumbsToShow.count, 1))
+    }
+    
     var body: some View {
         HStack(spacing: 0) {
-            ForEach(clip.thumbnails.indices, id: \.self) { i in
-                Image(uiImage: clip.thumbnails[i])
+            ForEach(Array(thumbsToShow.enumerated()), id: \.0) { _, img in
+                Image(uiImage: img)
                     .resizable()
                     .aspectRatio(contentMode: .fill)
-                    .frame(
-                        width: fullWidth / CGFloat(clip.thumbnails.count),
-                        height: 60
-                    )
+                    .frame(width: thumbnailWidth, height: 60)
                     .clipped()
             }
         }


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #175

## ✨ PR Content
> 작업 내용 설명을 적어주세요.

프로젝트 편집 내용 SwiftData에 저장하는 로직 추가했습니다.
이 과정에서 Action Sheet를 사용합니다.
내보내기 버튼을 누르면 갤러리에 저장되고, 저장 시점에 커스텀 알럿 표시됩니다.

## 📸 Screenshot
> 작업 화면의 스크린샷을 추가해주세요.

<img width="300" alt="IMG_3571" src="https://github.com/user-attachments/assets/f41bf6e6-128b-4827-b7ce-9a4f80b79886" />

<img width="300" alt="IMG_3575" src="https://github.com/user-attachments/assets/bcdb1838-01ea-46c8-b9d4-aa4d85438268" />

## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요

- 액션 시트 카피
문구가 적용되지 않은 부분들도 함께 수정했습니다. (ex. "A short ~~ ")


## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
