### PR TITLE
✨ [Feat] currentProjectID 플로우 반영

### DIFF
--- a/Chalkak/Presentation/Camera/CameraView.swift
+++ b/Chalkak/Presentation/Camera/CameraView.swift
@@ -145,6 +145,7 @@ struct CameraView: View {
 
     private func handleExitCamera() {
         viewModel.stopCamera()
+        UserDefaults.standard.set(nil, forKey: "currentProjectID")
         coordinator.removeAll()
     }
 }

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
@@ -82,6 +82,7 @@ struct ProjectEditView: View {
                 onToggleTrimming: viewModel.toggleTrimmingMode,
                 onTrimChanged: viewModel.updateTrimRange,
                 onAddClipTapped: {
+                    viewModel.setCurrentProjectID()
                     coordinator.push(.boundingBox(guide: viewModel.guide ?? nil))
                 }
             )

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
@@ -353,6 +353,6 @@ final class ProjectEditViewModel: ObservableObject {
     }
     
     func setCurrentProjectID() {
-        UserDefaults.standard.set(project?.id ?? nil, forKey: "currentProjectID")
+        UserDefaults.standard.set(projectID, forKey: "currentProjectID")
     }
 }

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
@@ -264,4 +264,8 @@ final class ProjectEditViewModel: ObservableObject {
       let idx = editableClips.firstIndex { $0.id == clip.id }!
       return editableClips[..<idx].reduce(0) { $0 + $1.trimmedDuration }
     }
+    
+    func setCurrentProjectID() {
+        UserDefaults.standard.set(project?.id ?? nil, forKey: "currentProjectID")
+    }
 }


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #이슈번호

## ✨ PR Content
> 작업 내용 설명을 적어주세요.

- 카메라를 빠져나갈 때 currentProjectID를 nil로 처리: 프로젝트 리스트에서 촬영을 마친 프로젝트도 disable처리되는 로직을 들어갈 수 있도록 개선했습니다
- 프로젝트 편집에서 클립추가 버튼 눌렀을 때 currentProjectID를 현재 편집중인 프로젝트로 세팅: 이어서 찍은 클립들이 currentProjectID를 참고해서 자동으로 붙고 있어서 이제 프로젝트 편집에서 플러스 버튼을 눌렀을 때 찍은 클립들이 추가되고, ProjectPreviewView와 프로젝트 편집에서 확인할 수 있습니다.


## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요

🐛 [fix] [#165](https://github.com/DeveloperAcademy-POSTECH/2025-C4-M15-Chalkak/issues/165) **프로젝트 편집 크래쉬 해결** 커밋은 해결된 줄 알고 커밋메시지를 그렇게 적었는데 아니었습니다.. **카메라에서 현재 프로젝트 빠져나가기 구현**이라고 생각해주세요..🥲

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
