### PR TITLE
🐛 [fix] 썸네일 생성 크래시 해결

### DIFF
--- a/Chalkak/Presentation/ProjectEdit/SubViews/ProjectThumbnailsView.swift
+++ b/Chalkak/Presentation/ProjectEdit/SubViews/ProjectThumbnailsView.swift
@@ -15,21 +15,33 @@ struct ProjectThumbnailsView: View {
     private var countWanted: Int {
         let duration = clip.isTrimming ? clip.originalDuration : clip.trimmedDuration
         let rate: Double = 3 // 초당 썸네일 개수
-        return max(1, Int(floor(duration * rate)))
+        return duration > 0 ? max(1, Int(ceil(duration * rate))) : 0
     }
 
-    /// 실제 표시할 썸네일 배열
+    /// 실제 표시할 썸네일 배열 (안전 버전)
     private var thumbsToShow: [UIImage] {
         let available = clip.thumbnails.count
-        let n = min(countWanted, available)
-        guard available > n else { return clip.thumbnails }
+        let wanted = countWanted
+
+        // 썸네일 자체가 없으면 빈 배열 반환 (상위에서 안전 처리 필요)
+        guard available > 0 else { return [] }
+
+        if wanted <= 1 {
+            return [clip.thumbnails[0]]
+        }
+
+        let n = min(wanted, available)
+        if n == available {
+            return clip.thumbnails
+        }
+        
         let step = Double(available - 1) / Double(n - 1)
         return (0..<n).map { idx in
             let i = Int(round(step * Double(idx)))
             return clip.thumbnails[i]
         }
     }
-
+    
     /// 썸네일 하나당 너비
     private var thumbnailWidth: CGFloat {
         fullWidth / CGFloat(max(thumbsToShow.count, 1))


### PR DESCRIPTION
- Thumbnail 생성하지 못한 경우, 첫번째 프레임으로 직접 생성하도록 개선

## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #192

## ✨ PR Content
> 작업 내용 설명을 적어주세요.

너무 짧게 촬영된 영상 (0.33초 이하)의 경우, 썸네일이 생성되지 못하면서
표시될 썸네일이 없어 앱이 크래시 나는 상황을 해결합니다.
썸네일을 생성하지 못한 경우, 해당 영상의 첫 프레임을 썸네일로 가지도록 추가 조건을 주어 해결했습니다.


## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
