### PR TITLE
🐛 [fix] #188 카메라/오디오 권한 여부에 따른 시트 로직 개선

### DIFF
--- a/Chalkak/Presentation/Camera/CameraView.swift
+++ b/Chalkak/Presentation/Camera/CameraView.swift
@@ -20,7 +20,6 @@ struct CameraView: View {
         }
     }
     
-    @StateObject private var cameraManager = CameraManager()
     @ObservedObject var viewModel: CameraViewModel
     @EnvironmentObject private var coordinator: Coordinator
 
@@ -143,7 +142,7 @@ struct CameraView: View {
         }
         .onAppear {
             viewModel.startCamera()
-            cameraManager.checkPermissions()
+            
         }
         .onDisappear {
             viewModel.stopCamera()
@@ -158,8 +157,8 @@ struct CameraView: View {
         }
         .snappieAlert(isPresented: $viewModel.showProjectSavedAlert, message: "프로젝트가 저장되었습니다")
         
-        .sheet(isPresented: $cameraManager.showPermissionSheet) {
-            CameraPermissionSheet(cameraManager: cameraManager)
+        .sheet(isPresented: $viewModel.showPermissionSheet) {
+            CameraPermissionSheet(viewModel: viewModel)
         }
     }
     

--- a/Chalkak/Presentation/Permission/PermissionCheckView.swift
+++ b/Chalkak/Presentation/Permission/PermissionCheckView.swift
@@ -4,21 +4,20 @@
 //
 //  Created by Murphy on 8/6/25.
 //
-import SwiftUI
 import AVFoundation
+import SwiftUI
 
 struct CameraPermissionSheet: View {
-    @ObservedObject var cameraManager: CameraManager
+    @ObservedObject var viewModel: CameraViewModel
     @Environment(\.dismiss) var dismiss
     
     var body: some View {
         NavigationView {
-            ZStack{
+            ZStack {
                 SnappieColor.darkHeavy.ignoresSafeArea()
                 
-                VStack(alignment: .leading, spacing: 40){
-                    
-                    VStack(alignment: .center, spacing: 24){
+                VStack(alignment: .leading, spacing: 40) {
+                    VStack(alignment: .center, spacing: 24) {
                         Text("카메라와 마이크 접근 권한 필요")
                             .font(.title)
                             .fontWeight(.bold)
@@ -30,11 +29,10 @@ struct CameraPermissionSheet: View {
                     }
                     
                     VStack(alignment: .leading, spacing: 24) {
-                        HStack(spacing: 8){
-                            
+                        HStack(spacing: 8) {
                             permissionIconCamera
                             
-                            VStack (alignment: .leading, spacing: 6){
+                            VStack(alignment: .leading, spacing: 6) {
                                 Text("카메라 접근 권한")
                                     .font(.headline)
                                     .fontWeight(.bold)
@@ -45,11 +43,10 @@ struct CameraPermissionSheet: View {
                             }
                         }
                         
-                        HStack(spacing: 8){
-                            
+                        HStack(spacing: 8) {
                             permissionIconAudio
                             
-                            VStack (alignment: .leading, spacing: 6){
+                            VStack(alignment: .leading, spacing: 6) {
                                 Text("마이크 접근 권한")
                                     .font(.headline)
                                     .fontWeight(.bold)
@@ -63,12 +60,12 @@ struct CameraPermissionSheet: View {
                     
                     Spacer()
                     
-                    VStack (alignment: .center){
+                    VStack(alignment: .center) {
                         SnappieButton(.solidPrimary(
                             title: "설정 열기",
                             size: .large
                         )) {
-                            cameraManager.openSettings()
+                            viewModel.openSettings()
                             dismiss()
                         }
                         .disabled(false)
@@ -78,53 +75,22 @@ struct CameraPermissionSheet: View {
                 .padding(.horizontal, 24)
                 .padding(.vertical, 48)
             }
-            
-        }
+         }
         .presentationBackground(.regularMaterial)
         .presentationCornerRadius(20)
-        
-    }
+     }
     
-    //권한에 따른 카메라 아이콘
     @ViewBuilder
     private var permissionIconCamera: some View {
-        switch cameraManager.permissionState {
-        case .both:
-            Image("cameraAuthorized")
-
-        case .cameraOnly:
-            Image("cameraAuthorized")
-            
-        case .audioOnly:
-            Image("cameraDenied")
-            
-        case .none:
-            Image("cameraDenied")
-        }
+        Image(viewModel.cameraPermissionIconName)
     }
     
-    //권한에 따른 마이크 아이콘
     @ViewBuilder
     private var permissionIconAudio: some View {
-        switch cameraManager.permissionState {
-        case .both:
-            Image("micAuthorized")
-            
-        case .cameraOnly:
-            Image("micDenied")
-            
-        case .audioOnly:
-            Image("micAuthorized")
-            
-        case .none:
-            Image("micDenied")
-        }
+        Image(viewModel.audioPermissionIconName)
     }
 }
 
-                    
-
-
 #Preview {
-    CameraPermissionSheet(cameraManager: CameraManager())
+    CameraPermissionSheet(viewModel: CameraViewModel())
 }


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #188 

## ✨ PR Content
- 카메라/오디오 권한 중 하나라도 허용이 안되있을 시 녹화버튼이 시트를 트리거하게끔 로직을 수정하였습니다. 
- ViewModel과 CameraManager를 좀 더 단순화 해줬습니다 ! 

## 📸 Screenshot
https://github.com/user-attachments/assets/75238813-59c6-4115-9c0a-4b8bdde79065

## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요
- 설정창으로 이동했다가 돌아올 때 시트가 다시 트리거되지는 않고 있는데, 이 부분은 당장 수정이 되질않아서, 머지 이후에 추가적으로 시도를 해보도록하겠습니다. 
- 그래도 허용이 되지않은 상태에서는 촬영 버튼을 누르면 시트가 정상적으로 나타나고 있어서  촬영 플로우에는 영향을 주지 않고 있기때문에 PR을 올립니다 ! 