### PR TITLE
🐛 [fix] #208 이미지 텍스트 영역 침범 수정

### DIFF
--- a/Chalkak/Presentation/ProjectList/SubViews/ProjectCard/ProjectCardCoverImageView.swift
+++ b/Chalkak/Presentation/ProjectList/SubViews/ProjectCard/ProjectCardCoverImageView.swift
@@ -37,7 +37,7 @@ struct ProjectCardCoverImageView: View {
                     image
                         .resizable()
                         .scaledToFill()
-                        .frame(width: geometry.size.width, alignment: .center)
+                        .frame(width: geometry.size.width, height: geometry.size.width, alignment: .center)
                         .clipShape(RoundedRectangle(cornerRadius: 16))
                     
                     Text(formattedTime)
@@ -56,14 +56,14 @@ struct ProjectCardCoverImageView: View {
                     .font(SnappieFont.style(.proBody1))
                     .multilineTextAlignment(.center)
                     .foregroundStyle(Color.deepGreen200)
-                    .frame(width: geometry.size.width, height: 173, alignment: .center)
+                    .frame(width: geometry.size.width, height: geometry.size.width, alignment: .center)
                     .background(
                         RoundedRectangle(cornerRadius: 16)
                             .fill(SnappieColor.darkStrong)
                     )
             }
         }
-        .frame(height: 173)
+        .aspectRatio(1, contentMode: .fit) // 정사각형 비율 유지
     }
 }
 


### PR DESCRIPTION

## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #208

## ✨ PR Content
> 작업 내용 설명을 적어주세요.

프레임 높이를 하드코딩하던 방식에서 1:1 비율의 이미지 컴포넌트로 보이도록 수정했습니다.

## 📸 Screenshot
> 작업 화면의 스크린샷을 추가해주세요.

|    before    |    After   |
| :-------------: | :----------: |
| <img src = "https://github.com/user-attachments/assets/c4e0c90f-73bb-4d04-aa40-62053e0b0f00" width ="250"> | <img src = "https://github.com/user-attachments/assets/ce8d76f4-a653-43ff-8759-ef432f712f06" width ="250"> |


## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요

- 오래 기다리셨습니다..고쳐왔습니다..! 😄

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
