### PR TITLE
✨ [Feat] #226 카메라 촬영 세션 딜레이 개선

### DIFF
--- a/Chalkak/Core/CameraKit/CameraManager.swift
+++ b/Chalkak/Core/CameraKit/CameraManager.swift
@@ -419,41 +419,6 @@ class CameraManager: NSObject, ObservableObject {
         }
     }
 
-    /// 터치한 위치값에 대한 초점을 조정하는 메소드
-//    func focusAtPoint(_ point: CGPoint) {
-//        guard let device = videoDeviceInput?.device else { return }
-//
-//        do {
-//            try device.lockForConfiguration()
-//
-//            // 부드러운 초점 전환을 위한 설정
-//            if device.isSmoothAutoFocusSupported {
-//                device.isSmoothAutoFocusEnabled = true
-//            }
-//
-//            // 초점,노출 지점접근
-//            device.focusPointOfInterest = point
-//            device.exposurePointOfInterest = point
-//
-//            // 초점
-//            if device.isFocusModeSupported(.continuousAutoFocus) {
-//                device.focusMode = .continuousAutoFocus
-//            } else if device.isFocusModeSupported(.autoFocus) {
-//                device.focusMode = .autoFocus
-//            }
-//
-//            // 노출
-//            if device.isExposureModeSupported(.continuousAutoExposure) {
-//                device.exposureMode = .continuousAutoExposure
-//            } else if device.isExposureModeSupported(.autoExpose) {
-//                device.exposureMode = .autoExpose
-//            }
-//
-//            device.unlockForConfiguration()
-//        } catch {
-//            print("디바이스 설정 변경오류\(error)")
-//        }
-//    }
     func focusAtPoint(_ point: CGPoint) {
         guard let device = videoDeviceInput?.device else { return }
 

--- a/Chalkak/Core/CameraKit/CameraManager.swift
+++ b/Chalkak/Core/CameraKit/CameraManager.swift
@@ -308,11 +308,13 @@ class CameraManager: NSObject, ObservableObject {
             // 카메라 기기가 지원하는 모든 포맷들을 하나씩 검사
             for format in device.formats {
                 /// 현재 촬영하고자하는 해상도 정보 추출
-                /// struct CMVideoDimensions { var width: Int32 / var height: Int32 }
+                /// struct CMVideoDimensions {
+                ///      var width: Int32 / var height: Int32
+                /// }
                 let dimensions = CMVideoFormatDescriptionGetDimensions(format.formatDescription)
                 let currentResolution = dimensions.width * dimensions.height
 
-                // 4K 이하 && 1080p(1920x1080 = 2,073,600)이하로 제한
+                // 4K까지는 의미X 1080p(1920x1080 = 2,073,600)이하로 제한
                 if currentResolution <= 2073600 {
                     // 이 포맷이 지원하는 프레임레이트 범위들을 확인
                     for range in format.videoSupportedFrameRateRanges {
@@ -334,14 +336,14 @@ class CameraManager: NSObject, ObservableObject {
             return
         }
 
-        // 찾은 최적 포맷을 실제 카메라에 적용
+        /// 디바이스 준비 이후 포맷과 fps가 적용될 수 있게 조정
         do {
             try device.lockForConfiguration()
-            device.activeFormat = format // 선택된 포맷 적용
+            device.activeFormat = format
+            device.unlockForConfiguration()
 
-            // 프레임 60fps로 고정 설정
+            try device.lockForConfiguration()
             let frameDuration = CMTime(value: 1, timescale: 60)
-            // 최대 - 최소 프레임 60fps
             device.activeVideoMinFrameDuration = frameDuration
             device.activeVideoMaxFrameDuration = frameDuration
             device.unlockForConfiguration()


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #226 

## ✨ PR Content
- setupCamera 관련 로직 비동기 로직 적용
- 포맷 변경과 프레임레이트 설정 간 race condition 해결 (lock/unlock Configuration 단계별 적용)
- 프레임레이트 설정 시 포맷 정보를 미리 확보한 상태에서 적용되도록, 포맷 탐색 로직을 동기로 다시 전환
- 비디오/카메라/오디오 세션 구성시 begin-commit Configuration으로 묶어주어 한번에 구성되도록 배치

## 📸 Screenshot

1차 개선 - 비동기 로직 적용 
https://github.com/user-attachments/assets/ec3ef05b-39d6-441b-8c97-eb581da49911

2차 개선 - 세션 구성 begin-commit Configuration 적용 - 세션 재구성 방지
https://github.com/user-attachments/assets/94fd6396-ca7e-4647-b443-38069ef2fd8c


## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요
- 특이 사항 1
사용되는게 begin/commit이 있고, lock-unlock 이렇게 Configuration 두종류가 있는데, 
AVFoundation에서도 내부적으로 이걸 각각 세션레벨 과 디바이스레벨로 분리하더라구요. 이후에는 CameraManager를 이 기준으로 리팩토링을 한 번 진행해보겠습니다. 
세션레벨 (AVCaptureSession) - 촬영에서 입력과 출력연결 
디바이스레벨(AVCaptureDevice) - 카메라 자체 설정 (줌,전/후면,밝기,초점 등..)

