### PR TITLE
✨ [Feat] 프로젝트 편집 - 클립 순서 변경

### DIFF
--- a/Chalkak.xcodeproj/project.pbxproj
+++ b/Chalkak.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		9340078F2E340467006BE89C /* VideoPreviewWithOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9340078E2E340467006BE89C /* VideoPreviewWithOverlay.swift */; };
 		934007912E3652C5006BE89C /* TrimmingHandleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934007902E3652BD006BE89C /* TrimmingHandleView.swift */; };
 		93A137672E32756A00777CF8 /* VideoControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A137662E32756A00777CF8 /* VideoControlView.swift */; };
+		93FE19812E56D83300E65416 /* TempClipData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93FE19802E56D82E00E65416 /* TempClipData.swift */; };
 		992EE7C22E32ACBA0079AFBF /* ProjectEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992EE7C12E32ACB50079AFBF /* ProjectEditView.swift */; };
 		992EE7C42E32ACFD0079AFBF /* ProjectEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992EE7C32E32ACF80079AFBF /* ProjectEditViewModel.swift */; };
 		992EE7C62E32AD900079AFBF /* TrimmingLineSliderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992EE7C52E32AD7B0079AFBF /* TrimmingLineSliderView.swift */; };
@@ -162,6 +163,7 @@
 		9340078E2E340467006BE89C /* VideoPreviewWithOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPreviewWithOverlay.swift; sourceTree = "<group>"; };
 		934007902E3652BD006BE89C /* TrimmingHandleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimmingHandleView.swift; sourceTree = "<group>"; };
 		93A137662E32756A00777CF8 /* VideoControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoControlView.swift; sourceTree = "<group>"; };
+		93FE19802E56D82E00E65416 /* TempClipData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempClipData.swift; sourceTree = "<group>"; };
 		992EE7C12E32ACB50079AFBF /* ProjectEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectEditView.swift; sourceTree = "<group>"; };
 		992EE7C32E32ACF80079AFBF /* ProjectEditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectEditViewModel.swift; sourceTree = "<group>"; };
 		992EE7C52E32AD7B0079AFBF /* TrimmingLineSliderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimmingLineSliderView.swift; sourceTree = "<group>"; };
@@ -358,6 +360,7 @@
 		992EE7CA2E32AECF0079AFBF /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				93FE19802E56D82E00E65416 /* TempClipData.swift */,
 				992EE7CB2E32AED70079AFBF /* EditableClip.swift */,
 			);
 			path = Model;
@@ -1087,6 +1090,7 @@
 				B6A592732E37CB4900D3DF6A /* CommonAlert.swift in Sources */,
 				993A1F7A2E267E0C0059B70A /* ProjectPreviewView.swift in Sources */,
 				992EE7C22E32ACBA0079AFBF /* ProjectEditView.swift in Sources */,
+				93FE19812E56D83300E65416 /* TempClipData.swift in Sources */,
 				0D5512F92E541723001FA7F9 /* OnboardingView.swift in Sources */,
 				993A1F7B2E267E0C0059B70A /* ProjectPreviewViewModel.swift in Sources */,
 				C5F7B6A12E2F6A2A0066B59C /* ButtonSolid.swift in Sources */,

--- a/Chalkak/App/ChalkakApp.swift
+++ b/Chalkak/App/ChalkakApp.swift
@@ -49,8 +49,8 @@ struct ChalkakApp: App {
                         case .projectPreview:
                             ProjectPreviewView()
                         
-                        case .projectEdit(let projectID):
-                            ProjectEditView(projectID: projectID)
+                        case .projectEdit(let projectID, let tempClipData):
+                            ProjectEditView(projectID: projectID, tempClipData: tempClipData)
                                 .toolbar(.hidden, for: .navigationBar)
                             
                         case .projectList:

--- a/Chalkak/Common/Util/Enum/Path.swift
+++ b/Chalkak/Common/Util/Enum/Path.swift
@@ -13,7 +13,6 @@ enum Path: Hashable {
     case camera(state: ShootState)
 
     case projectPreview
-    case projectEdit(projectID: String)
-
+    case projectEdit(projectID: String, tempClipData: TempClipData? = nil)
     case projectList
 }

--- a/Chalkak/Data/Model/Clip.swift
+++ b/Chalkak/Data/Model/Clip.swift
@@ -37,6 +37,14 @@ class Clip {
         max(0, endPoint - startPoint)
     }
     
+    /// 임시 클립 여부 (temp 프로젝트 내의 클립은 true)
+    var isTemp: Bool = false
+    
+    /// temp 클립이 참조하는 원본 클립의 ID
+    /// 새로 추가된 클립의 경우 nil
+    var originalClipID: String? = nil
+    
+    
     /// 새로운 Clip 인스턴스를 초기화합니다.
     /// - Parameters:
     ///   - id: 클립의 고유 ID (기본값은 UUID).
@@ -54,7 +62,9 @@ class Clip {
         startPoint: Double = 0,
         endPoint: Double,
         createdAt: Date = .now,
-        tiltList: [TimeStampedTilt] = []
+        tiltList: [TimeStampedTilt] = [],
+        isTemp: Bool = false,
+        originalClipID: String? = nil
     ) {
         self.id = id
         self.videoURL = videoURL
@@ -63,6 +73,8 @@ class Clip {
         self.endPoint = endPoint
         self.createdAt = createdAt
         self.tiltList = tiltList
+        self.isTemp = isTemp
+        self.originalClipID = originalClipID
     }
 }
 

--- a/Chalkak/Data/Model/Clip.swift
+++ b/Chalkak/Data/Model/Clip.swift
@@ -31,6 +31,9 @@ class Clip {
     
     /// 시간별로 기록된 카메라 기울기 정보.
     var tiltList: [TimeStampedTilt]
+    
+    /// 순서 보장을 위한 정보.
+    var order: Int = 0
         
     /// 트리밍된 시간을 계산한 정보.
     var currentTrimmedDuration: Double {

--- a/Chalkak/Data/Model/Guide.swift
+++ b/Chalkak/Data/Model/Guide.swift
@@ -45,7 +45,6 @@ class Guide: Identifiable {
         boundingBoxes: [BoundingBoxInfo],
         outlineImage: UIImage,
         cameraTilt: Tilt,
-        cameraHeight: Float,
         createdAt: Date = .now
     ) {
         self.clipID = clipID

--- a/Chalkak/Data/Model/Project.swift
+++ b/Chalkak/Data/Model/Project.swift
@@ -47,6 +47,14 @@ class Project: Identifiable {
         clipList.reduce(0) { $0 + $1.currentTrimmedDuration }
     }
     
+    /// 임시 프로젝트 여부 (편집 중인 프로젝트 = true)
+    var isTemp: Bool = false
+    
+    /// temp 프로젝트가 참조하는 원본 프로젝트의 ID
+    /// temp가 아닌 경우 nil
+    var originalID: String? = nil
+    
+    
     /// 새로운 `Project` 인스턴스를 초기화합니다.
     /// - Parameters:
     ///   - id: 고유 식별자 (기본값은 자동 생성된 UUID).
@@ -61,7 +69,9 @@ class Project: Identifiable {
         referenceDuration: Double? = nil,
         isChecked: Bool = false,
         coverImage: Data? = nil,
-        createdAt: Date = Date()
+        createdAt: Date = Date(),
+        isTemp: Bool = false,
+        originalID: String? = nil
     ) {
         self.id = id
         self.guide = guide
@@ -72,5 +82,7 @@ class Project: Identifiable {
         self.isChecked = isChecked
         self.coverImage = coverImage
         self.createdAt = createdAt
+        self.isTemp = isTemp
+        self.originalID = originalID
     }
 }

--- a/Chalkak/Data/SwiftDataManager.swift
+++ b/Chalkak/Data/SwiftDataManager.swift
@@ -104,13 +104,40 @@ class SwiftDataManager {
 
     /// `Project` 삭제
     func deleteProject(_ project: Project) {
+        // temp 프로젝트든 원본이든 관계없이 완전 삭제
+        // 클립들 개별 삭제
+        for clip in project.clipList {
+            context.delete(clip)
+        }
+        
+        // Guide 삭제
+        context.delete(project.guide)
+        
+        // CameraSetting 삭제 (있는 경우)
+        if let cameraSetting = project.cameraSetting {
+            context.delete(cameraSetting)
+        }
+        
+        // 프로젝트 삭제
         context.delete(project)
+        saveContext()
+    }
+    
+    /// `Temp Project` 안전 삭제 (temp 전용)
+    func deleteTempProject(_ tempProject: Project) {
+        guard tempProject.isTemp else {
+            print("경고: temp가 아닌 프로젝트를 temp 삭제 메서드로 삭제하려고 합니다.")
+            return
+        }
+        
+        context.delete(tempProject)
         saveContext()
     }
     
     /// 모든 프로젝트 조회
     func fetchAllProjects() -> [Project] {
-        let descriptor = FetchDescriptor<Project>()
+        let predicate = #Predicate<Project> { $0.isTemp == false }
+        let descriptor = FetchDescriptor<Project>(predicate: predicate)
         return (try? context.fetch(descriptor)) ?? []
     }
     
@@ -133,7 +160,7 @@ class SwiftDataManager {
     
     /// 확인하지 않은 프로젝트 조회
     func getUncheckedProjects() -> [Project] {
-        let predicate = #Predicate<Project> { $0.isChecked == false }
+        let predicate = #Predicate<Project> { $0.isChecked == false && $0.isTemp == false }
         let descriptor = FetchDescriptor<Project>(predicate: predicate)
         return (try? context.fetch(descriptor)) ?? []
     }
@@ -141,7 +168,7 @@ class SwiftDataManager {
     /// 뱃지 표시용 확인하지 않은 프로젝트 조회 (guide가 있고, 현재 촬영 중이 아닌 것)
     func getUncheckedProjectsForBadge() -> [Project] {
         let predicate = #Predicate<Project> { project in
-            project.isChecked == false
+            project.isChecked == false && project.isTemp == false
         }
         let descriptor = FetchDescriptor<Project>(predicate: predicate)
         let uncheckedProjects = (try? context.fetch(descriptor)) ?? []
@@ -228,15 +255,13 @@ class SwiftDataManager {
         clipID: String,
         boundingBoxes: [BoundingBoxInfo],
         outlineImage: UIImage,
-        cameraTilt: Tilt,
-        cameraHeight: Float
+        cameraTilt: Tilt
     ) -> Guide {
         let guide = Guide(
             clipID: clipID,
             boundingBoxes: boundingBoxes,
             outlineImage: outlineImage,
-            cameraTilt: cameraTilt,
-            cameraHeight: cameraHeight
+            cameraTilt: cameraTilt
         )
         context.insert(guide)
         return guide
@@ -287,6 +312,8 @@ class SwiftDataManager {
             try context.save()
         } catch {
             print("저장 실패: \(error)")
+            // 저장 실패 시 context rollback으로 일관성 유지
+            context.rollback()
         }
     }
 }

--- a/Chalkak/Presentation/ClipEdit/ClipEditView.swift
+++ b/Chalkak/Presentation/ClipEdit/ClipEditView.swift
@@ -106,14 +106,11 @@ struct ClipEditView: View {
                             case .followUpShoot:
                                 showActionSheet = true
                             case .appendShoot:
-                                print("appendShoot 분기 진입")
-                                editViewModel.appendClipToCurrentProject()
+                                let clipData = editViewModel.createTempClipData()
+                                
                                 if let projectID = editViewModel.fetchCurrentProjectID() {
                                     editViewModel.clearCurrentProjectID()
-                                    print("ProjectID 확인 후 push:", projectID)
-                                    coordinator.push(.projectEdit(projectID: projectID))
-                                } else {
-                                    print("⚠️ 프로젝트 ID가 없습니다.")
+                                    coordinator.push(.projectEdit(projectID: projectID, tempClipData: clipData))
                                 }
                             }
                         }

--- a/Chalkak/Presentation/ClipEdit/ClipEditViewModel.swift
+++ b/Chalkak/Presentation/ClipEdit/ClipEditViewModel.swift
@@ -318,4 +318,15 @@ final class ClipEditViewModel: ObservableObject {
     func clearCurrentProjectID() {
         UserDefaults.standard.set(nil, forKey: UserDefaultKey.currentProjectID)
     }
+    
+    // MARK: - Temp 관련 메소드
+    func createTempClipData() -> TempClipData {
+        return TempClipData(
+            url: clipURL,
+            originalDuration: duration,
+            startPoint: startPoint,
+            endPoint: endPoint,
+            tiltList: timeStampedTiltList
+        )
+    }
 }

--- a/Chalkak/Presentation/Guide/Overlay/OverlayViewModel.swift
+++ b/Chalkak/Presentation/Guide/Overlay/OverlayViewModel.swift
@@ -188,8 +188,7 @@ final class OverlayViewModel: ObservableObject {
             clipID: clipID,
             boundingBoxes: boundingBoxInfos,
             outlineImage: outlineImage,
-            cameraTilt: cameraTilt,
-            cameraHeight: 1.0
+            cameraTilt: cameraTilt
         )
         return guide
     }

--- a/Chalkak/Presentation/ProjectEdit/Model/TempClipData.swift
+++ b/Chalkak/Presentation/ProjectEdit/Model/TempClipData.swift
@@ -1,0 +1,28 @@
+//
+//  TempClipData.swift
+//  Chalkak
+//
+//  Created by Youbin on 8/21/25.
+//
+
+import Foundation
+
+struct TempClipData: Hashable {
+    let url: URL
+    let originalDuration: Double
+    let startPoint: Double
+    let endPoint: Double
+    let tiltList: [TimeStampedTilt]
+    
+    // EditableClip으로 변환
+    func toEditableClip() -> EditableClip {
+        return EditableClip(
+            id: UUID().uuidString,
+            url: url,
+            originalDuration: originalDuration,
+            startPoint: startPoint,
+            endPoint: endPoint,
+            thumbnails: []
+        )
+    }
+}

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
@@ -96,11 +96,11 @@ struct ProjectEditView: View {
         )
         .onAppear {
             Task {
-                // temp 프로젝트 초기화
-                await viewModel.initializeTempProject()
-                
                 // appendShoot에서 전달된 클립 데이터가 있으면 temp에 추가
                 if let clipData = tempClipData {
+                    // temp 프로젝트 초기화
+                    await viewModel.initializeTempProject(loadAfter: false)
+                    
                     viewModel.addClipToTemp(
                         clipURL: clipData.url,
                         originalDuration: clipData.originalDuration,
@@ -109,6 +109,9 @@ struct ProjectEditView: View {
                         tiltList: clipData.tiltList
                     )
                     tempClipData = nil
+                } else {
+                    // temp 프로젝트 초기화
+                    await viewModel.initializeTempProject(loadAfter: true)
                 }
             }
         }

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
@@ -76,6 +76,7 @@ struct ProjectEditView: View {
                     onSeek: viewModel.seekTo,
                     onToggleTrimming: viewModel.toggleTrimmingMode,
                     onTrimChanged: viewModel.updateTrimRange,
+                    onMove: viewModel.moveClip,
                     onAddClipTapped: {
                         viewModel.setCurrentProjectID()
                         guard let guide = viewModel.guide else {

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
@@ -472,7 +472,7 @@ final class ProjectEditViewModel: ObservableObject {
     
     //MARK: - Temp System 메서드들
     /// temp 프로젝트 초기화 (ProjectEditView 진입 시 호출)
-    func initializeTempProject() async {
+    func initializeTempProject(loadAfter: Bool = true) async {
         guard let originalProject = SwiftDataManager.shared.fetchProject(byID: projectID) else {
             print("원본 프로젝트를 찾을 수 없습니다.")
             return
@@ -480,7 +480,9 @@ final class ProjectEditViewModel: ObservableObject {
         
         // 이미 temp면 그대로 로드
         if originalProject.isTemp {
-            await loadProjectAsync()
+            if loadAfter {
+                await loadProjectAsync()
+            }
             return
         }
         
@@ -553,7 +555,9 @@ final class ProjectEditViewModel: ObservableObject {
         self.projectID = tempID
         self.project = tempProject
         
-        await loadProjectAsync()
+        if loadAfter {
+            await loadProjectAsync()
+        }
     }
 
     
@@ -589,18 +593,18 @@ final class ProjectEditViewModel: ObservableObject {
         SwiftDataManager.shared.saveContext()
         
 //        // UI 갱신을 위해 다시 로드
-//        Task {
-//            await loadProjectAsync()
-//        }
-        editableClips.append(EditableClip(
-            id: tempClip.id,
-            url: clipURL,
-            originalDuration: originalDuration,
-            startPoint: startPoint,
-            endPoint: endPoint,
-            thumbnails: []
-        ))
-        setupPlayer()
+        Task {
+            await loadProjectAsync()
+        }
+//        editableClips.append(EditableClip(
+//            id: tempClip.id,
+//            url: clipURL,
+//            originalDuration: originalDuration,
+//            startPoint: startPoint,
+//            endPoint: endPoint,
+//            thumbnails: []
+//        ))
+//        setupPlayer()
     }
     
     /// 클립 삭제 (temp에서만 안전하게 삭제)

--- a/Chalkak/Presentation/ProjectEdit/SubViews/ProjectTimelineView.swift
+++ b/Chalkak/Presentation/ProjectEdit/SubViews/ProjectTimelineView.swift
@@ -209,6 +209,9 @@ struct ProjectTimelineView: View {
     }
 
     // MARK: - Helpers (좌표/인덱스 계산)
+    /// 타임라인뷰의 글로벌 좌표 기준 시작지점 X를 계산합니다.
+    /// - Parameter geo: `GeometryReader`가 넘겨주는 현재 뷰의 지오메트리.
+    /// - Returns: 글로벌 좌표계에서 타임라인 콘텐츠의 선두(leading) X 값.
     private func contentStartGlobalX(_ geo: GeometryProxy) -> CGFloat {
         let frame = geo.frame(in: .global)
         let halfWidth = frame.size.width / 2
@@ -216,6 +219,9 @@ struct ProjectTimelineView: View {
         return frame.minX + halfWidth + timelineOffset
     }
 
+    /// 타임라인 내부에서 특정 클립의 왼쪽 모서리 X를 계산합니다.
+    /// - Parameter clipID: 위치를 구할 클립의 식별자.
+    /// - Returns: 콘텐츠 좌표계에서 해당 클립 leading X.
     private func leftXOfClipInContent(_ clipID: String) -> CGFloat {
         var accumulatedX: CGFloat = 0
         for (index, clip) in clips.enumerated() {
@@ -225,7 +231,14 @@ struct ProjectTimelineView: View {
         }
         return accumulatedX
     }
-
+    
+    /// 드래그 중인 클립의 왼쪽 모서리 X(콘텐츠 좌표계 기준) 를 바탕으로,
+    /// 현재 배열에서 어느 인덱스 앞에 삽입할지(갭 인덱스)를 계산합니다.
+    /// - Parameters:
+    ///   - leftX: 드래그 중인 클립의 leading X (콘텐츠 좌표계).
+    ///            일반적으로 `fingerGlobalX - contentStartGlobalX - dragAnchorWithinClip`.
+    ///   - sourceIndex: 드래그 중인 클립의 원본 배열 인덱스(자기 폭 제외 용도).
+    /// - Returns: 삽입할 갭 인덱스(0...`clips.count`). `clips.count`면 맨 뒤.
     private func computeInsertionIndex(leftX: CGFloat, sourceIndex: Int) -> Int {
         var accumulatedX: CGFloat = 0
         var reducedIdx = 0

--- a/Chalkak/Presentation/ProjectEdit/SubViews/ProjectTimelineView.swift
+++ b/Chalkak/Presentation/ProjectEdit/SubViews/ProjectTimelineView.swift
@@ -23,29 +23,33 @@ struct ProjectTimelineView: View {
     let onMove: (IndexSet, Int) -> Void
     let onAddClipTapped: () -> Void
 
-    // 드래그 앤 드롭을 위한 상태 변수
+    // 드래그 상태
     @State private var draggingClip: EditableClip?
     @State private var dragValue: DragGesture.Value?
     @State private var isDragActive = false
 
-    // 실시간 삽입 후보 위치(갭 인덱스)
+    // 삽입 후보 인덱스(gap)
     @State private var insertionIndex: Int?
-    
+
+    // 드래그 앵커(손가락이 클립 내부에서 찍힌 상대 X)
+    @State private var dragAnchorInClip: CGFloat?
+
     var body: some View {
         GeometryReader { geo in
             ZStack(alignment: .leading) {
-                // Layer 1: The scrollable timeline
+                // Layer 1: timeline content
                 HStack(alignment: .center, spacing: 0) {
                     ForEach(Array(clips.enumerated()), id: \.1.id) { index, clip in
                         let isBeingDragged = (draggingClip?.id == clip.id && isDragActive)
                         let clipWidth = clip.trimmedDuration * pxPerSecond
                         let draggingWidth = (draggingClip?.trimmedDuration ?? 0) * pxPerSecond
 
-                        // 후보 삽입 지점이면 갭(placeholder) 먼저 삽입
+                        // gap
                         if let insertionIndex, insertionIndex == index, isDragActive, draggingWidth > 0 {
                             insertionGap(width: draggingWidth)
                         }
-                        
+
+                        // 드래그 중 원본은 숨김(겹침 방지)
                         ClipTrimmingView(
                             clip: clip,
                             isDragging: $isDragging,
@@ -56,23 +60,22 @@ struct ProjectTimelineView: View {
                         .opacity(isBeingDragged ? 0.0 : 1.0)
                         .animation(.interactiveSpring(response: 0.22, dampingFraction: 0.88), value: insertionIndex)
                         .gesture(longPressDragGesture(clip: clip, geo: geo))
-                        
+
                         if clips.last?.id != clip.id {
                             Rectangle()
                                 .frame(width: 2, height: 8)
                                 .foregroundStyle(SnappieColor.primaryLight)
                         }
                     }
-                    
-                    // 리스트 끝에 삽입하는 경우(맨 뒤)
+
+                    // 맨 뒤 삽입
                     if let insertionIndex,
                        insertionIndex == clips.count,
                        isDragActive,
-                       let draggingClip
-                    {
+                       let draggingClip {
                         insertionGap(width: draggingClip.trimmedDuration * pxPerSecond)
                     }
-                    
+
                     Button(action: onAddClipTapped) {
                         Image("union")
                             .padding(.horizontal, 16)
@@ -93,11 +96,13 @@ struct ProjectTimelineView: View {
                 )
                 .clipped()
 
-                // Layer 2: The overlay for the currently dragged clip
+                // Layer 2: overlay (앵커 기반 왼쪽 정렬)
                 if let draggingClip = draggingClip, isDragActive, let dragValue = self.dragValue {
                     let clipWidth = draggingClip.trimmedDuration * pxPerSecond
-                    let fingerPosX = dragValue.location.x - geo.frame(in: .global).minX
-                    let offsetX = fingerPosX - (clipWidth / 2)
+                    let geoMinX = geo.frame(in: .global).minX
+                    let anchor: CGFloat = dragAnchorInClip ?? (clipWidth / 2)
+                    let leftGlobal = dragValue.location.x - anchor
+                    let offsetX = leftGlobal - geoMinX
 
                     ClipTrimmingView(
                         clip: draggingClip,
@@ -126,22 +131,33 @@ struct ProjectTimelineView: View {
             }
             .sequenced(before: DragGesture(minimumDistance: 0, coordinateSpace: .global))
             .onChanged { value in
-                guard case .second(true, let drag) = value,
-                          let drag = drag else { return }
+                guard case .second(true, let maybeDrag) = value,
+                      let drag = maybeDrag else { return }
                 self.dragValue = drag
-                
-                // 실시간 삽입 후보 계산
-                if let sourceIndex = clips.firstIndex(where: { $0.id == draggingClip?.id }) {
-                    let timelineFrame = geo.frame(in: .global)
-                    let timelineContentOffset = -CGFloat(playHeadPosition) * pxPerSecond + dragOffset
-                    let contentStartGlobalX = timelineFrame.minX + (timelineFrame.width / 2) + timelineContentOffset
-                    let relativeDropX = drag.location.x - contentStartGlobalX
 
-                    let candidate = getDestinationIndex(relativeDropX: relativeDropX, sourceIndex: sourceIndex)
-                    if insertionIndex != candidate {
-                        withAnimation(.interactiveSpring(response: 0.22, dampingFraction: 0.88)) {
-                            insertionIndex = candidate
-                        }
+                guard let draggingClip = draggingClip,
+                      let sourceIndex = clips.firstIndex(where: { $0.id == draggingClip.id }) else { return }
+
+                // 드래그 시작 시 1회 앵커 계산: (손가락 전역X) - (클립 전역 왼쪽X)
+                if dragAnchorInClip == nil {
+                    let contentStart = contentStartGlobalX(geo)
+                    let clipLeftInContent = leftXOfClipInContent(draggingClip.id)
+                    let clipLeftGlobal = contentStart + clipLeftInContent
+                    let width = draggingClip.trimmedDuration * pxPerSecond
+                    var anchor = drag.location.x - clipLeftGlobal
+                    anchor = max(0, min(anchor, width))
+                    dragAnchorInClip = anchor
+                }
+
+                // 현재 왼쪽X(콘텐츠 좌표) = 손가락X(전역) - contentStart(전역) - 앵커
+                let contentStart = contentStartGlobalX(geo)
+                let leftX = (drag.location.x - contentStart) - (dragAnchorInClip ?? 0)
+
+                // UI용 gap 인덱스(보정 없음)
+                let candidate = computeInsertionIndex(leftX: leftX, sourceIndex: sourceIndex)
+                if insertionIndex != candidate {
+                    withAnimation(.interactiveSpring(response: 0.22, dampingFraction: 0.88)) {
+                        insertionIndex = candidate
                     }
                 }
             }
@@ -152,52 +168,67 @@ struct ProjectTimelineView: View {
                         dragValue = nil
                         isDragActive = false
                         insertionIndex = nil
+                        dragAnchorInClip = nil
                     }
                 }
 
-                guard case .second(true, let drag) = value,
-                      let drag = drag,
-                      let sourceIndex = clips.firstIndex(where: { $0.id == draggingClip?.id })
-                else { return }
+                guard case .second(true, let maybeDrag) = value,
+                      let drag = maybeDrag,
+                      let draggingClip = draggingClip,
+                      let sourceIndex = clips.firstIndex(where: { $0.id == draggingClip.id }) else { return }
 
-                let timelineFrame = geo.frame(in: .global)
-                let timelineContentOffset = -CGFloat(playHeadPosition) * pxPerSecond + dragOffset
-                let contentStartGlobalX = timelineFrame.minX + (timelineFrame.width / 2) + timelineContentOffset
-                let relativeDropX = drag.location.x - contentStartGlobalX
+                let contentStart = contentStartGlobalX(geo)
+                let leftX = (drag.location.x - contentStart) - (dragAnchorInClip ?? 0)
 
-                let destinationIndex = getDestinationIndex(relativeDropX: relativeDropX, sourceIndex: sourceIndex)
-                onMove(IndexSet(integer: sourceIndex), destinationIndex)
+                let rawInsertion = insertionIndex ?? computeInsertionIndex(leftX: leftX, sourceIndex: sourceIndex)
+
+                onMove(IndexSet(integer: sourceIndex), rawInsertion)
             }
     }
-    
-    private func getDestinationIndex(relativeDropX: CGFloat, sourceIndex: Int) -> Int {
-        var accumulatedWidth: CGFloat = 0
-        var candidate = clips.count - 1
 
+    // MARK: - Helpers (좌표/인덱스 계산)
+    private func contentStartGlobalX(_ geo: GeometryProxy) -> CGFloat {
+        let frame = geo.frame(in: .global)
+        let halfWidth = frame.size.width / 2
+        let timelineOffset = -CGFloat(playHeadPosition) * pxPerSecond + dragOffset
+        return frame.minX + halfWidth + timelineOffset
+    }
+
+    private func leftXOfClipInContent(_ clipID: String) -> CGFloat {
+        var accumulatedX: CGFloat = 0
+        for (index, clip) in clips.enumerated() {
+            if clip.id == clipID { break }
+            accumulatedX += clip.trimmedDuration * pxPerSecond
+            if index < clips.count - 1 { accumulatedX += 2 } // 구분선 폭과 동일하게
+        }
+        return accumulatedX
+    }
+
+    private func computeInsertionIndex(leftX: CGFloat, sourceIndex: Int) -> Int {
+        var accumulatedX: CGFloat = 0
+        var reducedIdx = 0
+        let reducedCount = clips.count - 1
+        
         for (index, clip) in clips.enumerated() {
             if index == sourceIndex { continue }
-            
             let clipWidth = clip.trimmedDuration * pxPerSecond
-            let clipSpacing: CGFloat = (index < clips.count - 1) ? 2 : 0
-            
-            if relativeDropX < accumulatedWidth + (clipWidth + clipSpacing) / 2 {
-                candidate = index
-                break
-            }
-            accumulatedWidth += clipWidth + clipSpacing
+            let spacingAfter: CGFloat = (reducedIdx < reducedCount - 1) ? clipSpacing : 0
+            let boundaryMidX = accumulatedX + (clipWidth + spacingAfter) / 2
+            if leftX < boundaryMidX { return index }
+            accumulatedX += clipWidth + spacingAfter
+            reducedIdx += 1
         }
-        // SwiftUI onMove 규칙: 뒤에서 앞으로/앞에서 뒤로 이동할 때 인덱스 보정
-        return candidate > sourceIndex ? candidate - 1 : candidate
+        return clips.count
     }
-    
-    // MARK: - 갭(placeholder) 뷰
-   @ViewBuilder
-   private func insertionGap(width: CGFloat) -> some View {
-       RoundedRectangle(cornerRadius: 6)
-           .strokeBorder(style: StrokeStyle(lineWidth: 2, dash: [6, 6]))
-           .foregroundStyle(SnappieColor.primaryLight)
-           .frame(width: max(4, width), height: timelineHeight)
-           .transition(.opacity.combined(with: .move(edge: .leading)))
-           .animation(.easeInOut(duration: 0.18), value: insertionIndex)
-   }
+
+    // MARK: - gap 뷰
+    @ViewBuilder
+    private func insertionGap(width: CGFloat) -> some View {
+        RoundedRectangle(cornerRadius: 6)
+            .strokeBorder(style: StrokeStyle(lineWidth: 2, dash: [6, 6]))
+            .foregroundStyle(SnappieColor.primaryLight)
+            .frame(width: max(4, width), height: timelineHeight)
+            .transition(.opacity.combined(with: .move(edge: .leading)))
+            .animation(.easeInOut(duration: 0.18), value: insertionIndex)
+    }
 }

--- a/Chalkak/Presentation/ProjectEdit/SubViews/ProjectTimelineView.swift
+++ b/Chalkak/Presentation/ProjectEdit/SubViews/ProjectTimelineView.swift
@@ -20,58 +20,130 @@ struct ProjectTimelineView: View {
 
     let onToggleTrimming: (String) -> Void
     let onTrimChanged: (String, Double, Double) -> Void
+    let onMove: (IndexSet, Int) -> Void
     let onAddClipTapped: () -> Void
 
+    // 드래그 앤 드롭을 위한 상태 변수
+    @State private var draggingClip: EditableClip?
+    @State private var dragValue: DragGesture.Value?
+    @State private var isDragActive = false
+
     var body: some View {
-        
-        ForEach(Array(clips.enumerated()), id: \.offset) { index, item in
-            HStack {
-                Circle()
-                if index != clips.count - 1 {
-                    Rectangle()
-                }
-            }
-        }
-        
         GeometryReader { geo in
-            let halfWidth = geo.size.width / 2
-            HStack(alignment: .center, spacing: 0) {
-                ForEach(Array(clips.enumerated()), id: \.offset) { index, clip in
-                    
-                    ClipTrimmingView(
-                        clip: clip,
-                        isDragging: $isDragging,
-                        onToggleTrimming: { onToggleTrimming(clip.id) },
-                        onTrimChanged:   { s,e in onTrimChanged(clip.id, s, e) }
-                    )
-                    
-                    // 이어져있는것처럼 만들어주는 작은 선 컴포넌트
-                    if index != clips.count - 1 {
-                        Rectangle()
-                            .frame(width: 2, height: 8)
-                            .foregroundStyle(SnappieColor.primaryLight)
-                    }
-                }
-                Button(action: onAddClipTapped) {
-                    Image("union")
-                        .padding(.horizontal, 16)
-                        .frame(height: timelineHeight)
-                        .background(
-                            RoundedRectangle(cornerRadius: 6)
-                                .fill(SnappieColor.primaryLight)
+            ZStack(alignment: .leading) {
+                // Layer 1: The scrollable timeline
+                HStack(alignment: .center, spacing: 0) {
+                    ForEach(clips) { clip in
+                        let isBeingDragged = (draggingClip?.id == clip.id && isDragActive)
+
+                        ClipTrimmingView(
+                            clip: clip,
+                            isDragging: $isDragging,
+                            onToggleTrimming: { onToggleTrimming(clip.id) },
+                            onTrimChanged: { s, e in onTrimChanged(clip.id, s, e) }
                         )
+                        .opacity(isBeingDragged ? 0.4 : 1.0)
+                        .gesture(longPressDragGesture(clip: clip, geo: geo))
+                        
+                        if clips.last?.id != clip.id {
+                            Rectangle()
+                                .frame(width: 2, height: 8)
+                                .foregroundStyle(SnappieColor.primaryLight)
+                        }
+                    }
+                    
+                    Button(action: onAddClipTapped) {
+                        Image("union")
+                            .padding(.horizontal, 16)
+                            .frame(height: timelineHeight)
+                            .background(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .fill(SnappieColor.primaryLight)
+                            )
+                    }
+                    .padding(.leading, 2)
                 }
-                .padding(.leading, 2)
+                .padding(.horizontal, geo.size.width / 2)
+                .offset(x: -CGFloat(playHeadPosition) * pxPerSecond + dragOffset)
+                .frame(
+                    width: geo.size.width + CGFloat(totalDuration) * pxPerSecond,
+                    height: timelineHeight,
+                    alignment: .leading
+                )
+                .clipped()
+
+                // Layer 2: The overlay for the currently dragged clip
+                if let draggingClip = draggingClip, isDragActive, let dragValue = self.dragValue {
+                    let clipWidth = draggingClip.trimmedDuration * pxPerSecond
+                    let fingerPosX = dragValue.location.x - geo.frame(in: .global).minX
+                    let offsetX = fingerPosX - (clipWidth / 2)
+
+                    ClipTrimmingView(
+                        clip: draggingClip,
+                        isDragging: .constant(true),
+                        onToggleTrimming: { },
+                        onTrimChanged: { _, _ in }
+                    )
+                    .frame(width: clipWidth)
+                    .offset(x: offsetX)
+                    .scaleEffect(1.1)
+                    .shadow(radius: 10)
+                }
             }
-            .padding(.horizontal, halfWidth)
-            .offset(x: -CGFloat(playHeadPosition) * pxPerSecond + dragOffset)
-            .frame(
-                width: geo.size.width + CGFloat(totalDuration) * pxPerSecond,
-                height: timelineHeight,
-                alignment: .leading
-            )
-            .clipped()
         }
         .frame(height: timelineHeight)
+    }
+
+    // MARK: - Drag & Drop Gesture
+    private func longPressDragGesture(clip: EditableClip, geo: GeometryProxy) -> some Gesture {
+        LongPressGesture(minimumDuration: 0.5)
+            .onEnded { _ in
+                withAnimation(.spring()) {
+                    draggingClip = clip
+                    isDragActive = true
+                }
+            }
+            .sequenced(before: DragGesture(minimumDistance: 0, coordinateSpace: .global))
+            .onChanged { value in
+                guard case .second(true, let drag) = value else { return }
+                self.dragValue = drag
+            }
+            .onEnded { value in
+                if case .second(true, let drag) = value, let drag = drag, let sourceIndex = clips.firstIndex(where: { $0.id == draggingClip?.id }) {
+                    let timelineFrame = geo.frame(in: .global)
+                    let timelineContentOffset = -CGFloat(playHeadPosition) * pxPerSecond + dragOffset
+                    let contentStartGlobalX = timelineFrame.minX + (timelineFrame.width / 2) + timelineContentOffset
+                    let relativeDropX = drag.location.x - contentStartGlobalX
+                    
+                    let destinationIndex = getDestinationIndex(relativeDropX: relativeDropX, sourceIndex: sourceIndex)
+                    
+                    onMove(IndexSet(integer: sourceIndex), destinationIndex)
+                }
+                
+                withAnimation(.spring()) {
+                    draggingClip = nil
+                    dragValue = nil
+                    isDragActive = false
+                }
+            }
+    }
+    
+    private func getDestinationIndex(relativeDropX: CGFloat, sourceIndex: Int) -> Int {
+        var accumulatedWidth: CGFloat = 0
+        var targetIndex = 0
+
+        for (index, clip) in clips.enumerated() {
+            if index == sourceIndex { continue } // Skip the original item
+            
+            let clipWidth = clip.trimmedDuration * pxPerSecond
+            let clipSpacing: CGFloat = (index < clips.count - 1) ? 2 : 0
+            
+            if relativeDropX < accumulatedWidth + (clipWidth + clipSpacing) / 2 {
+                return index > sourceIndex ? index - 1 : index
+            }
+            accumulatedWidth += clipWidth + clipSpacing
+        }
+        
+        return clips.count - 1
     }
 }

--- a/Chalkak/Presentation/ProjectEdit/SubViews/TrimmingLineSliderView.swift
+++ b/Chalkak/Presentation/ProjectEdit/SubViews/TrimmingLineSliderView.swift
@@ -17,6 +17,7 @@ struct TrimminglineSliderView: View {
     let onSeek: (Double) -> Void
     let onToggleTrimming: (String) -> Void
     let onTrimChanged: (String, Double, Double) -> Void
+    let onMove: (IndexSet, Int) -> Void
     let onAddClipTapped: () -> Void
 
     private let pxPerSecond: CGFloat = 50
@@ -52,6 +53,7 @@ struct TrimminglineSliderView: View {
                     timelineHeight: timelineHeight,
                     onToggleTrimming: onToggleTrimming,
                     onTrimChanged: onTrimChanged,
+                    onMove: onMove,
                     onAddClipTapped: onAddClipTapped
                 )
                 .gesture(


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #218

## ✨ PR Content
> 작업 내용 설명을 적어주세요.
프로젝트 편집 시점의 클립 순서 변경을 구현하였습니다.
길게 눌렀을 경우 순서이동이 가능하며, 순서 이동 시점에 위치에 따라서 들어가게 될 자리를 표시해줍니다. 드랍 시점에 해당 위치에 추가됩니다.
최종 저장시점에 순서 변경 내역이 저장됩니다.


## 📸 Screenshot
> 작업 화면의 스크린샷을 추가해주세요.

https://github.com/user-attachments/assets/5cae20b5-03cf-494d-a60a-4bba90fa8c15

## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요


- clip의 순서 보장을 위해서 order 속성(필드)를 추가했습니다.
앱 한번 삭젝 후 다시 다운받아주세요!


## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
